### PR TITLE
Kubernetes: Allow logdna DS pods to run on master

### DIFF
--- a/logdna-agent-ds-master.yaml
+++ b/logdna-agent-ds-master.yaml
@@ -9,9 +9,7 @@ spec:
         app: logdna-agent
     spec:
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - operator: Exists
       containers:
       - name: logdna-agent
         image: logdna/logdna-agent:latest
@@ -24,7 +22,11 @@ spec:
                 key: logdna-agent-key
           - name: LOGDNA_PLATFORM
             value: k8s
+        #  - name: LOGDNA_TAGS
+        #    value: production,cluster1,othertags
         resources:
+          requests:
+            cpu: 20m
           limits:
             memory: 500Mi
         volumeMounts:
@@ -32,6 +34,9 @@ spec:
           mountPath: /var/log
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: mnt
+          mountPath: /mnt
           readOnly: true
         - name: docker
           mountPath: /var/run/docker.sock
@@ -46,6 +51,9 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: mnt
+        hostPath:
+          path: /mnt
       - name: docker
         hostPath:
           path: /var/run/docker.sock

--- a/logdna-agent-ds.yaml
+++ b/logdna-agent-ds.yaml
@@ -8,6 +8,10 @@ spec:
       labels:
         app: logdna-agent
     spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: logdna-agent
         image: logdna/logdna-agent:latest


### PR DESCRIPTION
The DaemonSet does not launch pods on master nodes anymore.

My env:-

Kops: 1.6.0-beta.1
Kubernetes: v1.6.2 (created using kops flag `--channel alpha`)

The DS only runs on worker nodes and skips the masters, this is because the masters have the following [taint](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature):-

```
  taints:
  - effect: NoSchedule
    key: node-role.kubernetes.io/master
    timeAdded: null
```
I don't know if this taint is created by kops, or is a kubernetes(1.6.x) default. This pull request instructs the DS to ignore this taint.
