### PR TITLE
Added binary and manpage for binary

### DIFF
--- a/logdna-agent
+++ b/logdna-agent
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+node index.js "$@"

--- a/logdna-agent.1
+++ b/logdna-agent.1
@@ -1,4 +1,4 @@
-.TH LOGDNA-AGENT 1 2017-01-08 Linux
+.TH LOGDNA-AGENT 1 2018-01-08 Linux
 .SH NAME
 logdna\-agent \- agent for LogDNA logging
 .SH SYNOPSIS

--- a/logdna-agent.1
+++ b/logdna-agent.1
@@ -1,0 +1,58 @@
+.TH LOGDNA-AGENT 1 2017-01-08 Linux
+.SH NAME
+logdna\-agent \- agent for LogDNA logging
+.SH SYNOPSIS
+.B logdna\-agent
+[\fB\-k\fR \fIINGESTION_KEY\fR]
+[\fB\-\-key\fR \fIINGESTION_KEY\fR]
+[\fB\-c\fR \fICONFIG_FILE\fR]
+[\fB\-\-config\fR \fICONFIG_FILE\fR]
+[\fB\-d\fR \fIFOLDER\fR]
+[\fB\-\-logdir\fR \fIFOLDER\fR]
+[\fB\-f\fR \fIFILE\fR]
+[\fB\-\-logfile\fR \fIFILE\fR]
+[\fB\-e\fR \fIFILE\fR]
+[\fB\-\-exclude\fR \fIFILE\fR]
+[\fB\-r\fR \fIPATTERN\fR]
+[\fB\-\-exclude\-regex\fR \fIPATTERN\fR]
+[\fB\-n\fR \fIHOSTNAME\fR]
+[\fB\-\-hostname\fR \fIHOSTNAME\fR]
+[\fB\-t\fR \fITAGS\fR]
+[\fB\-\-tags\fR \fITAGS\fR]
+[\fB\-h\fR]
+[\fB\-\-help\fR]
+[\fB\-v\fR]
+[\fB\-\-version\fR]
+.SH DESCRIPTION
+logdna-agent is a command line interface that allows logging files and folders to the LogDNA API.
+.SH OPTIONS
+.TP
+.BR \-k \", \" \-\-key \fIINGESTION_KEY\fR
+Sets the ingestion key for the agent. Keys are unique to every user and can be found in your control panel at app.logdna.com. This will generate a configuration file which is saved at /etc/logdna.conf.
+.TP
+.BR \-c \", \" \-\-config \fICONFIG_FILE\fR
+Uses an alternate configuration file. The default is found at /etc/logdna.conf.
+.TP
+.BR \-d \", \" \-\-logdir \fIFOLDER\fR
+Recursively adds a folders files for monitoring. Supports glob patterns e.g. /var/log/*.txt or /var/log/**/myapp.log. By default, /var/log is already added.
+.TP
+.BR \-f \", \" \-\-logfile \fIFILE\fR
+Specifies a file that should be monitored.
+.TP
+.BR \-e \", \" \-\-exclude \fIFILE\fR
+Specifies files that should be excluded from \-d.
+.TP
+.BR \-r \", \" \-\-exclude-regex \fIPATTERN\fR
+Filters out lines that match the pattern.
+.TP
+.BR \-n \", \" \-\-hostname \fIHOSTNAME\fR
+Uses alternate hostname.
+.TP
+.BR \-t \", \" \-\-tags \fITAGS\fR
+Sets tag for this host (for autogrouping). Multiple tags must be comma separated.
+.TP
+.BR \-h \", \" \-\-help
+Lists all the available commands.
+.TP
+.BR \-v \", \" \-\-version
+Displays version information.


### PR DESCRIPTION
Added a binary that can be put into /usr/bin which works well with package managers. Includes a simple man page for it.

Can be used like:

logdna-agent -k <INGESTION_KEY>
logdna-agent -d "/var/log/**/app.log"