### PR TITLE
It now supports multiple Windows Event Log Providers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ function checkElevated() {
 }
 
 config.UA = pkg.name + '/' + pkg.version;
+config.CONF_FILE = program.config || config.DEFAULT_CONF_FILE;
 
 checkElevated()
     .then(isElevated => {
@@ -86,7 +87,7 @@ checkElevated()
             process.exit();
         }
 
-        return properties.parseAsync(program.config || config.DEFAULT_CONF_FILE, { path: true })
+        return properties.parseAsync(config.CONF_FILE, { path: true })
             .catch(() => {});
     })
     .then(parsedConfig => {

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -76,13 +76,13 @@ module.exports.connectLogServer = function(config, programName) {
         socket.on('open', function() {
             log('Connected to ' + config.LOGDNA_LOGHOST + ':' + config.LOGDNA_LOGPORT + ' (' + socket._socket.remoteAddress + ')' + (config.LOGDNA_LOGSSL ? ' (SSL)' : '') + (proxy ? ' via ' + proxy : ''));
 
-            if (config.windowseventlogprovider) {
-                config.windowseventlogprovider = config.windowseventlogprovider.replace(' ', '').split(',');
+            if (config.windowseventlogproviders) {
+                config.windowseventlogproviders = config.windowseventlogproviders.replace(' ', '').split(',');
             }
 
-            if (os.platform() === 'win32' && config.windowseventlogprovider) {
+            if (os.platform() === 'win32' && config.windowseventlogproviders) {
                 log('Streaming Windows event log data');
-                winUtils.streamEventLog(config.windowseventlogprovider, socket);
+                winUtils.streamEventLog(config.windowseventlogproviders, socket);
             }
 
             if (firstrun) {

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -84,9 +84,17 @@ module.exports.connectLogServer = function(config, programName) {
                 });
             }
 
-            if (os.platform() === 'win32' && config.windowseventlogproviders) {
-                log('Streaming Windows event log data');
-                winUtils.streamEventLog(config.windowseventlogproviders, socket);
+            if (os.platform() === 'win32') {
+                // Plural Case:
+                if (config.windowseventlogproviders) {
+                    log('Streaming multiple Windows Event Logs data');
+                    winUtils.streamEventLog(config.windowseventlogproviders, socket);
+                }
+                // Singular Case:
+                if (config.windowseventlogprovider) {
+                    log('Streaming Windows Event Log data');
+                    winUtils.streamEventLog([config.windowseventlogprovider], socket);
+                }
             }
 
             if (firstrun) {

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -77,7 +77,11 @@ module.exports.connectLogServer = function(config, programName) {
             log('Connected to ' + config.LOGDNA_LOGHOST + ':' + config.LOGDNA_LOGPORT + ' (' + socket._socket.remoteAddress + ')' + (config.LOGDNA_LOGSSL ? ' (SSL)' : '') + (proxy ? ' via ' + proxy : ''));
 
             if (config.windowseventlogproviders) {
-                config.windowseventlogproviders = config.windowseventlogproviders.replace(' ', '').split(',');
+                config.windowseventlogproviders = config.windowseventlogproviders.split(',').map((provider) => {
+                    return provider.trim();
+                }).filter((provider) => {
+                    return provider !== '';
+                });
             }
 
             if (os.platform() === 'win32' && config.windowseventlogproviders) {

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -76,6 +76,10 @@ module.exports.connectLogServer = function(config, programName) {
         socket.on('open', function() {
             log('Connected to ' + config.LOGDNA_LOGHOST + ':' + config.LOGDNA_LOGPORT + ' (' + socket._socket.remoteAddress + ')' + (config.LOGDNA_LOGSSL ? ' (SSL)' : '') + (proxy ? ' via ' + proxy : ''));
 
+            if (config.windowseventlogprovider) {
+                config.windowseventlogprovider = config.windowseventlogprovider.replace(' ', '').split(',');
+            }
+
             if (os.platform() === 'win32' && config.windowseventlogprovider) {
                 log('Streaming Windows event log data');
                 winUtils.streamEventLog(config.windowseventlogprovider, socket);

--- a/lib/windows-utilities.js
+++ b/lib/windows-utilities.js
@@ -3,9 +3,9 @@ var debug = require('debug')('logdna:lib:file-utilities');
 var log = require('./log');
 var linebuffer = require('./linebuffer');
 
-module.exports.streamEventLog = function(provider) {
+module.exports.streamEventLog = function(providers) {
     var winEvent = new WinEventReader({
-        providers: [provider]
+        providers: providers
         , startTime: new Date(Date.now())
         , endTime: new Date(Date.now())
         , frequency: 2000

--- a/lib/windows-utilities.js
+++ b/lib/windows-utilities.js
@@ -4,7 +4,6 @@ var log = require('./log');
 var linebuffer = require('./linebuffer');
 
 module.exports.streamEventLog = function(providers) {
-    console.log(providers);
     var winEvent = new WinEventReader({
         providers: providers
         , startTime: new Date(Date.now())

--- a/lib/windows-utilities.js
+++ b/lib/windows-utilities.js
@@ -4,6 +4,7 @@ var log = require('./log');
 var linebuffer = require('./linebuffer');
 
 module.exports.streamEventLog = function(providers) {
+    console.log(providers);
     var winEvent = new WinEventReader({
         providers: providers
         , startTime: new Date(Date.now())

--- a/test/lib/windows-utilities.js
+++ b/test/lib/windows-utilities.js
@@ -39,7 +39,7 @@ describe('lib:windows-utilities', function() {
                     log.info('arbitraryData');
                 }, 1000);
 
-                windowsUtilities.streamEventLog(provider, socket);
+                windowsUtilities.streamEventLog([provider], socket);
                 debug(socket);
             });
         });


### PR DESCRIPTION
In the configuration file, log providers should be separated by commas like the following:
```
{
  ...
  windowseventlogproviders = Application, System, Directory Service, DNS Server
  ...
}
```

I'm removing whitespaces and splitting by `,` - and `winUtils.streamEventLog` originally takes array of providers not a single provider... 

**Note**: [AppVeyor Check](https://ci.appveyor.com/project/mikehu/logdna-agent/build/1.0.238) failed, `--force` should be added. Also, @leeliu , v1.5.0 should be released for Windows.