### PR TITLE
set requests.cpu

### DIFF
--- a/logdna-agent-ds.yaml
+++ b/logdna-agent-ds.yaml
@@ -23,6 +23,8 @@ spec:
         #  - name: LOGDNA_TAGS
         #    value: production,cluster1,othertags
         resources:
+          requests:
+            cpu: 20m
           limits:
             memory: 500Mi
         volumeMounts:


### PR DESCRIPTION
this is the same as #27

our master died and dns-controller wouldn't start because there were no resources because logdna was taking them.