### PR TITLE
init script: source /etc/sysconfig/logdna-agent if it exists

### DIFF
--- a/scripts/init-script
+++ b/scripts/init-script
@@ -20,6 +20,10 @@ pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.log"
 conf_file="/etc/logdna.conf"
 
+if [ -f /etc/sysconfig/$name ]; then
+    . /etc/sysconfig/$name
+fi
+
 get_pid() {
     cat "$pid_file"
 }


### PR DESCRIPTION
This provides a standard way to source environment variables for the agent (things like HTTP_PROXY or HTTPS_PROXY) see #38 