### PR TITLE
Fixing NPM Vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '5.9.0'
+- '6.10.2'
 env:
   - CXX=g++-4.8
 addons:
@@ -15,7 +15,7 @@ cache:
   - node_modules
 before_install:
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm@^6"
   - export DEBUG=logdna*
 install:
 - npm install

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var debug = require('debug')('logdna:index');
 var log = require('./lib/log');
 var program = require('commander');
 var pkg = require('./package.json');
-var _ = require('lodash');
 var os = require('os');
 var fs = require('fs');
 
@@ -236,7 +235,7 @@ checkElevated()
         }
 
         // merge into single var after all potential saveConfigs finished
-        _.extend(config, parsedConfig);
+        config = Object.assign(config, parsedConfig);
 
         // debug(console.log(config));
 

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -67,8 +67,6 @@ module.exports.getAuthToken = function(config, agentName, socket) {
             if (process.env.LDLOGHOST || process.env.LDLOGPORT) {
                 config.LOGDNA_LOGHOST = config.LOGDNA_LOGHOST || 'logs.logdna.com';
                 config.LOGDNA_LOGPORT = config.LOGDNA_LOGPORT || 443;
-                config.LOGDNA_LOGSSL = config.LOGDNA_LOGSSL;
-
             } else {
                 config.LOGDNA_LOGHOST = body.server;
                 config.LOGDNA_LOGPORT = body.port;

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -4,7 +4,6 @@ var debug = require('debug')('logdna:lib:connection-manager');
 var log = require('./log');
 var spawn = require('child_process').spawn;
 var os = require('os');
-var _ = require('lodash');
 var url = require('url');
 var fileUtils = require('./file-utilities');
 var winUtils = require('./windows-utilities');
@@ -84,7 +83,7 @@ module.exports.connectLogServer = function(config, programName) {
                 fileUtils.streamAllLogs(config);
 
                 if (os.platform() === 'win32' && config.winevent) {
-                    if (_.isString(config.winevent)) {
+                    if (typeof config.winevent === 'string') {
                         config.winevent = config.winevent.split(',');
                     }
 

--- a/lib/file-utilities.js
+++ b/lib/file-utilities.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var debug = require('debug')('logdna:lib:file-utilities');
 var log = require('./log');
 var _ = require('lodash');
-var Tail = require('always-tail');
 var linebuffer = require('./linebuffer');
 var glob = require('glob');
 var async = require('async');
@@ -113,23 +112,6 @@ module.exports.streamFiles = function(config, logfiles, callback) {
             });
 
             tails.push(tail);
-
-        } else if (config.TAIL_MODE === 'lib') {
-            try {
-                tail = new Tail(file, '\n', { interval: 100, blockSize: 10 * 1024 * 1024 });
-            } catch (err) {
-                log('Error tailing ' + file + ': ' + err);
-                return callback && callback(err);
-            }
-
-            debug('tailing: ' + file);
-            tail.on('line', function(line) {
-                linebuffer.addMessage({ t: Date.now(), l: line, f: file, label: labels });
-            });
-            tail.on('error', function(err) {
-                log('Tail error: ' + file + ': ' + err);
-            });
-            tail.watch();
 
         } else {
             debug('tailing: ' + file);

--- a/lib/file-utilities.js
+++ b/lib/file-utilities.js
@@ -127,7 +127,7 @@ module.exports.streamFiles = function(config, logfiles, callback) {
             tail.on('end', (err) => {
                 if (err) {
                     log('File does not exist, stopped tailing: ' + file + ' after ' + tail.timeout + 'ms');
-                    exports.files = exports.files.filter(element => element != file);
+                    exports.files = exports.files.filter(element => element !== file);
                 }
             });
 

--- a/lib/file-utilities.js
+++ b/lib/file-utilities.js
@@ -2,7 +2,6 @@ var properties = require('properties');
 var fs = require('fs');
 var debug = require('debug')('logdna:lib:file-utilities');
 var log = require('./log');
-var _ = require('lodash');
 var linebuffer = require('./linebuffer');
 var glob = require('glob');
 var async = require('async');
@@ -89,7 +88,7 @@ module.exports.getFiles = function(config, dir, callback) {
 };
 
 module.exports.streamFiles = function(config, logfiles, callback) {
-    _.each(logfiles, function(file) {
+    logfiles.forEach((file) => {
         var tail, i, labels;
 
         if (config.platform && config.platform.indexOf('k8s') === 0) {
@@ -128,7 +127,7 @@ module.exports.streamFiles = function(config, logfiles, callback) {
             tail.on('end', (err) => {
                 if (err) {
                     log('File does not exist, stopped tailing: ' + file + ' after ' + tail.timeout + 'ms');
-                    _.pull(exports.files, file);
+                    exports.files = exports.files.filter(element => element != file);
                 }
             });
 
@@ -155,10 +154,11 @@ module.exports.streamAllLogs = function(config, callback) {
                 debug(logfiles);
 
                 // figure out new files that we're not already tailing
-                var diff = _.difference(logfiles, exports.files);
+                var diff = logfiles.filter(element => exports.files.indexOf(element) < 0);
 
                 // unique filenames between logdir(s)
-                newfiles = _.uniq(newfiles.concat(diff));
+                newfiles = newfiles.concat(diff);
+                newfiles = newfiles.filter((element, index) => newfiles.indexOf(element) === index);
                 debug('newfiles after processing ' + dir);
                 debug(newfiles);
 
@@ -264,7 +264,7 @@ module.exports.appender = function(xs) {
 module.exports.gracefulShutdown = function(signal) {
     log('Got ' + signal + ' signal, shutting down...');
     setTimeout(function() { process.exit(); }, 5000);
-    _.each(tails, function(tail) {
+    tails.forEach((tail) => {
         tail.kill('SIGTERM');
         debug('tail pid ' + tail.pid + ' killed');
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ const stringify = (obj) => {
 
     const maxKeyLength = Object.keys(obj).reduce((maxLen, key) => {
         return key.length > maxLen ? key.length : maxLen;
-    }, 0)
+    }, 0);
 
     return Object(obj).reduce((lines, key) => {
 
@@ -88,7 +88,7 @@ const pick2list = (options, config) => {
 
 // Custom UnSetting Configuration:
 const unsetConfig = (options, config) => {
-    options = merge(options.map(option => exports.split(option).filter(element => element != 'key')));
+    options = merge(options.map(option => exports.split(option).filter(element => element !== 'key')));
     const lowOptions = options.map(value => value.toLowerCase());
     if (lowOptions.indexOf('all') > -1) {
         return {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,23 +1,20 @@
-const _ = require('lodash');
-
 // Custom Splitter:
-const split = function(str, delimiter) {
-    delimiter = delimiter || ',';
-    return _.compact(_.map(str.split(delimiter), _.trim));
+const split = (str, delimiter) => {
+    return (str.split(delimiter || ',').map(element => element.trim())).filter(element => element);
 };
 
 // Custom JSON Stringifier:
-const stringify = function(obj) {
+const stringify = (obj) => {
 
-    var maxKeyLength = _.reduce(obj, (maxLen, value, key) => {
+    const maxKeyLength = Object.keys(obj).reduce((maxLen, key) => {
         return key.length > maxLen ? key.length : maxLen;
-    }, 0);
+    }, 0)
 
-    return _.reduce(obj, (lines, value, key) => {
+    return Object(obj).reduce((lines, key) => {
 
-        value = value !== null && value.toString().split(',') || '';
+        var value = obj[key] !== null && obj[key].toString().split(',') || '';
 
-        if (_.isArray(value)) {
+        if (Array.isArray(value)) {
             if (value.length > 1) {
                 value = '[ ' + value.join(', ') + ' ]';
             }
@@ -25,7 +22,7 @@ const stringify = function(obj) {
             value = value.toString();
         }
 
-        key = key + _.repeat(' ', maxKeyLength - key.length) + ' =';
+        key = key + ' '.repeat(maxKeyLength - key.length) + ' =';
 
         lines.push(key + ' ' + value);
 
@@ -35,48 +32,49 @@ const stringify = function(obj) {
 };
 
 // Custom Scaled Merger:
-const merge = function(objects, is_json) {
+const merge = (objects, is_json) => {
     is_json = is_json || false;
     if (is_json) {
-        return _.reduce(objects, (merged, obj) => {
-            merged.push(_.merge(merged.pop(), obj));
+        return objects.reduce((merged, obj) => {
+            merged.push(Object.assign(merged.pop(), obj));
             return merged;
         }, [{}])[0];
     }
-    return _.reduce(objects, (merged, obj) => {
-        if (!_.isArray(obj)) obj = [obj];
-        merged.push(_.uniq(merged.pop().concat(obj)));
-        return _.uniq(merged);
+    return objects.reduce((merged, obj) => {
+        if (!Array.isArray(obj)) obj = [obj];
+        const arr = merged.pop().concat(obj);
+        merged.push(arr.filter((element, index) => arr.indexOf(element) === index));
+        return merged.filter((element, index) => merged.indexOf(element) === index);
     }, [[]])[0];
 };
 
 // Custom Processing - Combining all processes:
-const processOption = function(options, config) {
-    const newValues = merge(_.map(options, (option) => {
-        return exports.split(option);
-    }));
-    const oldValues = (config ? (_.isString(config) ? exports.split(config) : config) : []);
-    const diff = _.uniq(_.difference(newValues, oldValues));
+const processOption = (options, config) => {
+    const newValues = merge(options.map(option => exports.split(option)));
+    const oldValues = (config ? (typeof config === 'string' ? exports.split(config) : config) : []);
+    const diff = newValues.filter(value => oldValues.indexOf(value) < 0).filter(value => value);
     return {
-        values: _.uniq(merge([oldValues, newValues]))
-        , diff: _.isEmpty(diff) ? 'Nothing new has' : (diff.length > 1 ? diff.join(', ') + ' have' : diff[0] + ' has')
+        values: merge([oldValues, newValues]).filter(element => element)
+        , diff: diff.length === 0 ? 'Nothing new has' : (diff.length > 1 ? diff.join(', ') + ' have' : diff[0] + ' has')
     };
 };
 
 // Pick the Keys to List Values of:
-const pick2list = function(options, config) {
-    const lowOptions = _.map(options, (value) => {
-        return value.toLowerCase();
-    });
-    if (_.includes(lowOptions, 'all')) {
+const pick2list = (options, config) => {
+    const lowOptions = options.map(value => value.toLowerCase());
+    if (lowOptions.indexOf('all') > -1) {
         return {
             cfg: config
             , valid: true
         };
     }
 
-    config = _.pick(config, options);
-    if (_.isEmpty(config)) {
+    config = Object.keys(config).reduce((obj, key) => {
+        if (options.indexOf(key) > -1) obj[key] = config[key];
+        return obj;
+    }, {});
+
+    if (Object.keys(config).length === 0) {
         return {
             valid: false
             , msg: 'Invalid or Bad Parameter'
@@ -89,14 +87,10 @@ const pick2list = function(options, config) {
 };
 
 // Custom UnSetting Configuration:
-const unsetConfig = function(options, config) {
-    options = merge(_.map(options, (option) => {
-        return _.without(exports.split(option), 'key');
-    }));
-    const lowOptions = _.map(options, (value) => {
-        return value.toLowerCase();
-    });
-    if (_.includes(lowOptions, 'all')) {
+const unsetConfig = (options, config) => {
+    options = merge(options.map(option => exports.split(option).filter(element => element != 'key')));
+    const lowOptions = options.map(value => value.toLowerCase());
+    if (lowOptions.indexOf('all') > -1) {
         return {
             cfg: {
                 key: config.key
@@ -106,10 +100,13 @@ const unsetConfig = function(options, config) {
     }
 
     const oldValues = (config ? Object.keys(config) : []);
-    config = _.omit(config, options);
+    config = Object.keys(config).reduce((obj, key) => {
+        if (options.indexOf(key) === -1) obj[key] = config[key];
+        return obj;
+    }, {});
     const newValues = (config ? Object.keys(config) : []);
-    const diff = _.uniq(_.difference(oldValues, newValues));
-    const message = _.isEmpty(diff) ? 'Nothing has' : (diff.length > 1 ? diff.join(', ') + ' have' : diff[0] + ' has');
+    const diff = oldValues.filter(value => newValues.indexOf(value) < 0).filter(value => value);
+    const message = diff.length === 0 ? 'Nothing has' : (diff.length > 1 ? diff.join(', ') + ' have' : diff[0] + ' has');
     return {
         cfg: config
         , msg: message + ' been deleted!'

--- a/lib/welp.js
+++ b/lib/welp.js
@@ -60,7 +60,7 @@ CustomWELR.prototype._checkLogString = (logString, logName) => {
 };
 
 CustomWELR.prototype.streamEvents = () => {
-    this.options.events.map((event) => {
+    this.options.events.forEach((event) => {
         var logs = '';
         var PS = 'powershell -ExecutionPolicy Bypass "' + this.script + ' ' + event + '"';
         this.powershell = exec(PS);

--- a/lib/welp.js
+++ b/lib/welp.js
@@ -1,7 +1,6 @@
-var exec = require('child_process').exec;
-var _ = require('lodash');
-var fs = require('fs');
-var script = require('./config').DEFAULT_WINTAIL_FILE;
+const exec = require('child_process').exec;
+const fs = require('fs');
+const script = require('./config').DEFAULT_WINTAIL_FILE;
 
 function CustomWELR(options) {
     this.options = options;
@@ -13,7 +12,7 @@ function CustomWELR(options) {
     this.script = fs.existsSync(script) ? script : './scripts/windows/winTail.ps1';
 }
 
-CustomWELR.prototype.on = function(eventName, cb) {
+CustomWELR.prototype.on = (eventName, cb) => {
     if (typeof cb !== 'function') {
         throw new Error('Must provide a function callback');
     }
@@ -30,7 +29,7 @@ CustomWELR.prototype.on = function(eventName, cb) {
     }
 };
 
-CustomWELR.prototype._cleanLogString = function(logString) {
+CustomWELR.prototype._cleanLogString = (logString) => {
     var str = logString;
     str = str.replace(' ', '');
     str = str.replace('\n', '');
@@ -44,14 +43,14 @@ CustomWELR.prototype._cleanLogString = function(logString) {
     return str;
 };
 
-CustomWELR.prototype._checkLogString = function(logString, logName) {
+CustomWELR.prototype._checkLogString = (logString, logName) => {
     try {
         var parsedJSON = JSON.parse(this._cleanLogString(logString));
-        if (!_.isArray(parsedJSON)) {
+        if (!Array.isArray(parsedJSON)) {
             parsedJSON.EventName = logName;
             return [JSON.stringify(parsedJSON)];
         }
-        return _.map(parsedJSON, (parsed) => {
+        return parsedJSON.map((parsed) => {
             parsed.EventName = logName;
             return JSON.stringify(parsed);
         });
@@ -60,8 +59,8 @@ CustomWELR.prototype._checkLogString = function(logString, logName) {
     }
 };
 
-CustomWELR.prototype.streamEvents = function() {
-    _.forEach(this.options.events, (event) => {
+CustomWELR.prototype.streamEvents = () => {
+    this.options.events.map((event) => {
         var logs = '';
         var PS = 'powershell -ExecutionPolicy Bypass "' + this.script + ' ' + event + '"';
         this.powershell = exec(PS);

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "node-windows": "^0.1.11"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.3",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-curl": "^2.2.0",
     "grunt-eslint": "^20.0.0",
     "grunt-exec": "^0.4.6",
     "grunt-line-remover": "0.0.2",
-    "grunt-mocha-cli": "^2.0.0",
+    "grunt-mocha-cli": "^4.0.0",
     "grunt-zip": "^0.17.1",
     "guid": "0.0.12",
     "load-grunt-tasks": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "glob": "^7.0.3",
     "https-proxy-agent": "^2.1.0",
     "is-administrator": "^1.0.1",
-    "lodash": "^3.10.1",
     "macaddress": "^0.2.8",
     "properties": "^1.2.1",
     "request": "^2.71.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "homepage": "https://github.com/logdna/logdna-agent",
   "dependencies": {
     "agentkeepalive": "^2.1.1",
-    "always-tail": "^0.2.0",
     "async": "^1.5.2",
     "bluebird": "^3.5.3",
     "bufferutil": "^1.2.1",

--- a/test/lib/connection-manager.js
+++ b/test/lib/connection-manager.js
@@ -6,7 +6,7 @@ var path = require('path');
 var assert = require('assert');
 var debug = require('debug')('logdna:test:lib:connection-manager');
 var mockery = require('mockery');
-var rimraf = Promise.promisify(require('rimraf'));
+var rimraf = require('rimraf');
 var skeemas = require('skeemas');
 var statsSchema = require('../helpers/message-schemas/stats');
 var logSchema = require('../helpers/message-schemas/log');
@@ -32,7 +32,7 @@ describe('lib:connection-manager', function() {
         }
     };
 
-    before(function(done) {
+    before((done) => {
         // setup spawn mock
         mockery.enable({
             warnOnUnregistered: false
@@ -41,11 +41,10 @@ describe('lib:connection-manager', function() {
         mockery.registerMock('child_process', cpMock);
 
         debug('cleaning up test folder...' + tempDir);
-        return rimraf(tempDir)
-            .then(() => {
-                fs.mkdirSync(tempDir);
-                return done();
-            });
+        return rimraf(tempDir, () => {
+            fs.mkdirSync(tempDir);
+            return done();
+        });
     });
 
     after(function() {

--- a/test/lib/file-utilities.js
+++ b/test/lib/file-utilities.js
@@ -1,21 +1,27 @@
-/* globals describe, it, beforeEach */
+/* globals describe, it, beforeEach, after */
 require('../helpers/before');
 var assert = require('assert');
 var debug = require('debug')('logdna:test:lib:file-utilities');
 var fs = require('fs');
 var path = require('path');
-var rimraf = Promise.promisify(require('rimraf'));
+var rimraf = require('rimraf');
 var tempDir = '.temp';
 
 describe('lib:file-utilities', function() {
-    beforeEach(function(done) {
+
+    beforeEach((done) => {
         debug('cleaning up test folder...' + tempDir);
-        return rimraf(tempDir)
-            .then(() => {
-                fs.mkdirSync(tempDir);
-                fs.mkdirSync(path.join(tempDir, 'subdir'));
-                return done();
-            });
+        return rimraf(tempDir, () => {
+            fs.mkdirSync(tempDir);
+            fs.mkdirSync(path.join(tempDir, 'subdir'));
+            return done();
+        });
+    });
+
+    after(function() {
+        return rimraf(tempDir, () => {
+            return debug('Cleaned');
+        });
     });
 
     describe('#getFiles()', function() {
@@ -34,12 +40,9 @@ describe('lib:file-utilities', function() {
                 fs.writeFileSync(testFiles[i], 'arbitraryData\n');
             }
 
-            return new Promise(resolve => {
-                fileUtilities.getFiles({}, tempDir, function(err, array) {
-                    debug(array);
-                    assert.equal(array.length, testFiles.length, 'Expected to find all log files');
-                    resolve(true);
-                });
+            fileUtilities.getFiles({}, tempDir, function(err, array) {
+                debug(array);
+                assert.equal(array.length, testFiles.length, 'Expected to find all log files');
             });
         });
 
@@ -58,12 +61,9 @@ describe('lib:file-utilities', function() {
                 fs.writeFileSync(testFiles[i], 'arbitraryData\n');
             }
 
-            return new Promise(resolve => {
-                fileUtilities.getFiles({}, tempDir, function(err, array) {
-                    debug(array);
-                    assert.equal(array.length, 0, 'Expected to find no log files');
-                    resolve(true);
-                });
+            fileUtilities.getFiles({}, tempDir, function(err, array) {
+                debug(array);
+                assert.equal(array.length, 0, 'Expected to find no log files');
             });
         });
 
@@ -79,12 +79,9 @@ describe('lib:file-utilities', function() {
                 fs.writeFileSync(testFiles[i], 'arbitraryData\n');
             }
 
-            return new Promise(resolve => {
-                fileUtilities.getFiles({}, path.join(tempDir, '*.txt'), function(err, array) {
-                    debug(array);
-                    assert.equal(array.length, 1, 'Expected to find only 1 log file, not recursive');
-                    resolve(true);
-                });
+            fileUtilities.getFiles({}, path.join(tempDir, '*.txt'), function(err, array) {
+                debug(array);
+                assert.equal(array.length, 1, 'Expected to find only 1 log file, not recursive');
             });
         });
 
@@ -102,12 +99,9 @@ describe('lib:file-utilities', function() {
                 fs.writeFileSync(testFiles[i], 'arbitraryData\n');
             }
 
-            return new Promise(resolve => {
-                fileUtilities.getFiles({}, path.join(tempDir, '**', '*.txt'), function(err, array) {
-                    debug(array);
-                    assert.equal(array.length, 2, 'Expected to find 2 log files, recursive');
-                    resolve(true);
-                });
+            fileUtilities.getFiles({}, path.join(tempDir, '**', '*.txt'), function(err, array) {
+                debug(array);
+                assert.equal(array.length, 2, 'Expected to find 2 log files, recursive');
             });
         });
     });
@@ -131,29 +125,25 @@ describe('lib:file-utilities', function() {
             var fileUtilities = require('../../lib/file-utilities');
             fileUtilities.files = [];
 
-            return new Promise((resolve) => {
-                var expectedCount = 2;
-                var count = 0;
-                server.on('message', data => {
-                    debug('received message!');
-                    debug(data);
-                    var message = JSON.parse(data);
-                    assert(message.ls[0].l, 'arbitraryData1');
-                    assert(message.ls[1].l, 'arbitraryData2');
+            var expectedCount = 2;
+            var count = 0;
+            server.on('message', data => {
+                debug('received message!');
+                debug(data);
+                var message = JSON.parse(data);
+                assert(message.ls[0].l, 'arbitraryData1');
+                assert(message.ls[1].l, 'arbitraryData2');
 
-                    count += message.ls.length;
+                count += message.ls.length;
 
-                    if (count === expectedCount) {
-                        resolve(true);
-                    }
-                });
+                if (count === expectedCount) return true;
+            });
 
-                fs.writeFileSync(path.join(tempDir, 'streamtest3.log'), '');
-                fileUtilities.streamAllLogs(config, function() {
-                    // simulate a program writing to a log file
-                    fs.appendFileSync(path.join(tempDir, 'streamtest3.log'), 'arbitraryData1\n');
-                    fs.appendFileSync(path.join(tempDir, 'streamtest3.log'), 'arbitraryData2\n');
-                });
+            fs.writeFileSync(path.join(tempDir, 'streamtest3.log'), '');
+            fileUtilities.streamAllLogs(config, function() {
+                // simulate a program writing to a log file
+                fs.appendFileSync(path.join(tempDir, 'streamtest3.log'), 'arbitraryData1\n');
+                fs.appendFileSync(path.join(tempDir, 'streamtest3.log'), 'arbitraryData2\n');
             });
         });
 
@@ -174,29 +164,25 @@ describe('lib:file-utilities', function() {
             var fileUtilities = require('../../lib/file-utilities');
             fileUtilities.files = [];
 
-            return new Promise((resolve) => {
-                var expectedCount = 2;
-                var count = 0;
-                server.on('message', data => {
-                    debug('received message!');
-                    debug(data);
-                    var message = JSON.parse(data);
-                    assert(message.ls[0].l, 'arbitraryData1');
-                    assert(message.ls[1].l, 'arbitraryData2');
+            var expectedCount = 2;
+            var count = 0;
+            server.on('message', data => {
+                debug('received message!');
+                debug(data);
+                var message = JSON.parse(data);
+                assert(message.ls[0].l, 'arbitraryData1');
+                assert(message.ls[1].l, 'arbitraryData2');
 
-                    count += message.ls.length;
+                count += message.ls.length;
 
-                    if (count === expectedCount) {
-                        resolve(true);
-                    }
-                });
+                if (count === expectedCount) return true;
+            });
 
-                fs.writeFileSync(path.join(tempDir, 'streamtest4.log'), '');
-                fileUtilities.streamAllLogs(config, function() {
-                    // simulate a program writing to a log file
-                    fs.appendFileSync(path.join(tempDir, 'streamtest4.log'), 'arbitraryData1\n');
-                    fs.appendFileSync(path.join(tempDir, 'streamtest4.log'), 'arbitraryData2\n');
-                });
+            fs.writeFileSync(path.join(tempDir, 'streamtest4.log'), '');
+            fileUtilities.streamAllLogs(config, function() {
+                // simulate a program writing to a log file
+                fs.appendFileSync(path.join(tempDir, 'streamtest4.log'), 'arbitraryData1\n');
+                fs.appendFileSync(path.join(tempDir, 'streamtest4.log'), 'arbitraryData2\n');
             });
         });
 
@@ -217,31 +203,27 @@ describe('lib:file-utilities', function() {
             var fileUtilities = require('../../lib/file-utilities');
             fileUtilities.files = [];
 
-            return new Promise((resolve) => {
-                var expectedCount = 2;
-                var count = 0;
-                server.on('message', data => {
-                    debug('received message!');
-                    debug(data);
-                    var message = JSON.parse(data);
-                    assert(message.ls[0].l, 'arbitraryData1');
-                    assert(message.ls[1].l, 'arbitraryData2');
+            var expectedCount = 2;
+            var count = 0;
+            server.on('message', data => {
+                debug('received message!');
+                debug(data);
+                var message = JSON.parse(data);
+                assert(message.ls[0].l, 'arbitraryData1');
+                assert(message.ls[1].l, 'arbitraryData2');
 
-                    count += message.ls.length;
+                count += message.ls.length;
 
-                    if (count === expectedCount) {
-                        resolve(true);
-                    }
-                });
+                if (count === expectedCount) return true;
+            });
 
-                fs.writeFileSync(path.join(tempDir, 'streamtest5.log'), '');
-                fileUtilities.streamAllLogs(config, function() {
-                    // simulate a program writing to a log file
-                    setTimeout(function() {
-                        fs.appendFileSync(path.join(tempDir, 'streamtest5.log'), 'arbitraryData1\n');
-                        fs.appendFileSync(path.join(tempDir, 'streamtest5.log'), 'arbitraryData2\n');
-                    }, 500);
-                });
+            fs.writeFileSync(path.join(tempDir, 'streamtest5.log'), '');
+            fileUtilities.streamAllLogs(config, function() {
+                // simulate a program writing to a log file
+                setTimeout(function() {
+                    fs.appendFileSync(path.join(tempDir, 'streamtest5.log'), 'arbitraryData1\n');
+                    fs.appendFileSync(path.join(tempDir, 'streamtest5.log'), 'arbitraryData2\n');
+                }, 500);
             });
         });
 
@@ -263,36 +245,34 @@ describe('lib:file-utilities', function() {
             var fileUtilities = require('../../lib/file-utilities');
             fileUtilities.files = [];
 
-            return new Promise((resolve) => {
-                var expectedCount = 3;
-                var count = 0;
-                server.on('message', data => {
-                    debug('received message!');
-                    debug(data);
-                    var message = JSON.parse(data);
-                    if (count === 0) {
-                        assert(message.ls[0].l, 'arbitraryData1');
-                        assert(message.ls[1].l, 'arbitraryData2');
-                    } else if (count === 2) {
-                        assert(message.ls[0].l, 'arbitraryData3');
-                    }
-                    count += message.ls.length;
+            var expectedCount = 3;
+            var count = 0;
+            server.on('message', data => {
+                debug('received message!');
+                debug(data);
+                var message = JSON.parse(data);
+                if (count === 0) {
+                    assert(message.ls[0].l, 'arbitraryData1');
+                    assert(message.ls[1].l, 'arbitraryData2');
+                } else if (count === 2) {
+                    assert(message.ls[0].l, 'arbitraryData3');
+                }
+                count += message.ls.length;
 
-                    if (count === expectedCount) {
-                        config.RESCAN_INTERVAL = -1;
-                        resolve(true);
-                    }
-                });
+                if (count === expectedCount) {
+                    config.RESCAN_INTERVAL = -1;
+                    return true;
+                }
+            });
 
-                fs.writeFileSync(path.join(tempDir, 'streamtest6.log'), '');
-                fileUtilities.streamAllLogs(config, function() {
-                    // simulate a program writing to a log file
-                    fs.appendFileSync(path.join(tempDir, 'streamtest6.log'), 'arbitraryData1\n');
-                    fs.appendFileSync(path.join(tempDir, 'streamtest6.log'), 'arbitraryData2\n');
+            fs.writeFileSync(path.join(tempDir, 'streamtest6.log'), '');
+            fileUtilities.streamAllLogs(config, function() {
+                // simulate a program writing to a log file
+                fs.appendFileSync(path.join(tempDir, 'streamtest6.log'), 'arbitraryData1\n');
+                fs.appendFileSync(path.join(tempDir, 'streamtest6.log'), 'arbitraryData2\n');
 
-                    // simulate new file after RESCAN_INTERVAL
-                    fs.writeFileSync(path.join(tempDir, 'streamtest7.log'), 'arbitraryData3\n');
-                });
+                // simulate new file after RESCAN_INTERVAL
+                fs.writeFileSync(path.join(tempDir, 'streamtest7.log'), 'arbitraryData3\n');
             });
         });
     });


### PR DESCRIPTION
Finally, could have fixed it:
- removed `lodash` and replaced with built-in functionalities;
- removed `always-tail` since no need for that;
- updated `grunt` version from `0.4.5` to `1.0.3`;
- updated `grunt-mocha-cli` version from `2.0.0` to `4.0.0`;
- since `grunt-mocha-cli` is using `mocha@4.0.0`, I had to modify the test suites to support `mocha@4.0.0` - `Mocha` had new and core changes in `v3.0.0` and newer versions listed [here](https://github.com/mochajs/mocha/pull/2350) and [here](https://github.com/mochajs/old-mochajs-site/pull/48/files) - `grunt-mocha-cli@2.0.0` is using `mocha@2.0.0` and having `high` and `critical` vulnerabilities;
- now, `npm audit fix` (after `npm install` and having `package-lock.json`) says there is no vulnerability at all.

Tested on `Node v6.10.2` and `NPM v8.4.1`.