### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ LogDNA's collector agent which streams log files to your LogDNA account. LogDNA 
 
 ### From an Official Release
 
-Check out the official [LogDNA site](https://logdna.com/) on how to signup for an account and get started.
+Check out the official [LogDNA site](https://logdna.com/) to learn how to sign up for an account and get started.
 
 ### From Source
 
-Follow these quick instructions to run the LogDNA agent from source:
+Follow these instructions to run the LogDNA agent from source:
 
 ```bash
 git clone https://github.com/logdna/logdna-agent.git
@@ -25,11 +25,11 @@ sudo node index.js --help
 
 # configure
 sudo node index.js -k <YOUR LOGDNA INGESTION KEY>
-# On Linux, this will generate a config file: /etc/logdna.conf
-# On Windows, this will generate a config file: C:\ProgramData\logdna\logdna.conf
+# On Linux, this will generate a config file at: /etc/logdna.conf
+# On Windows, this will generate a config file at: C:\ProgramData\logdna\logdna.conf
 
-# on Linux, /var/log is monitored/added by default (recursively), optionally specify more folders
-# on Windows, C:\ProgramData\logs is monitored/added by default (recursively), optionally specify more folders
+# on Linux, /var/log is monitored/added by default (recursively). You can optionally specify more folders
+# on Windows, C:\ProgramData\logs is monitored/added by default (recursively). You can optionally specify more folders
 sudo node index.js -d /path/to/log/folders -d /path/to/2nd/folder
 sudo node index.js -d /var/log                            # folder only assumes *.log + extensionless files
 sudo node index.js -d "/var/log/*.txt"                    # supports glob patterns
@@ -53,40 +53,41 @@ sudo node index.js -u all                                 # unset everything exc
 sudo node index.js
 ```
 
+Note that when using glob patterns with `index.js`, you must enclose the pattern in double quotes.
+
 ### Configuration File
 
-Normally a config file is automatically generated (e.g. when you set a key using `-k`), but you can create your own config file `/etc/logdna.conf` on Linux and `C:\ProgramData\logdna\logdna.conf` on Windows:
+Normally a config file is automatically generated (e.g. when you set a key using `index.js -k`) and updated (e.g. when you add a directory using `index.js -d`) but you can create your own config file `/etc/logdna.conf` on Linux and `C:\ProgramData\logdna\logdna.conf` on Windows and save your settings there:
 
 ```conf
 logdir = /var/log/myapp,/path/to/2nd/dir
 key = <YOUR LOGDNA INGESTION KEY>
 ```
-On Windows, you can use Windows paths, just make sure to use `\\` as a separator:
+On Windows, use `\\` as a separator:
 
 ```conf
 logdir = C:\\Users\\username\\AppData\\myapp
 key = <YOUR LOGDNA INGESTION KEY>
 ```
 
-#### Options
-* `logdir`: sets the paths that the agent will monitor for new files, separate multiple paths using `,`, supports glob patterns + specific files. By default this option is set to monitor .log and extensionless files under `/var/log/`. Glob patterns should be given in double-quotes.
-* `exclude`: excludes files that otherwise would've matched `logdir`, separate multiple excludes using `,`, supports glob patterns + specific files
-* `exclude_regex`: filters out any lines matching pattern in any file. Don't include leading and trailing /.
-* `key`: your LogDNA Ingestion Key. You can obtain one by creating an account on [LogDNA site](https://logdna.com/) and once logged in to the webapp, click the Gear icon, then Account Profile.
-* `tags`: use tags to separate data for production, staging, or autoscaling use cases
-* `hostname`: override os hostname
-* `autoupdate`: sets whether the agent should update itself when new versions are available on the public repo (default is `1`, set to `0` to disable)
+#### Configuration File Options
+* `logdir`: sets the paths that the agent will monitor for new files. Multiple paths can be specified, separated by `,`. Supports glob patterns + specific files. By default this option is set to monitor `.log` and extensionless files under `/var/log/`.
+* `exclude`: sets files to exclude that would otherwise match what's set in `logdir`. Multiple paths can be specified, separated by `,`. Supports glob patterns + specific files
+* `exclude_regex`: filters out any log lines matching this pattern in any file. Should not include leading or trailing `/`.
+* `key`: your LogDNA Ingestion Key. You can obtain one by creating an account at [LogDNA](https://logdna.com/). Once logged in, click on the Gear icon, then Account Profile to find your key.
+* `tags`: tags can be used e.g. to separate data from production, staging, or autoscaling use cases
+* `hostname`: set this to override the os hostname
+* `autoupdate`: whether the agent should update itself when new versions are available on the public repo (default is `1`, set to `0` to disable)
 * `winevent`: sets Windows Event Log Configurations in `logname` format
 
-
 ### Features
-* Agent maintains persistent connections to LogDNA ingestion servers with HTTPS encryption
+* The Agent maintains persistent connections to LogDNA ingestion servers with HTTPS encryption
 * Reconnects if disconnected and will queue up new log lines while disconnected
-* Compression on upload (currently gzip)
-* Rescans for new files in all `logdir` paths, every minute
-* Transparently handles log rotated files in most OS's (supports: renamed, truncated & "new file per day" log rotation methods)
+* Compresses on upload (gzip)
+* Rescans for new files in all `logdir` paths every minute
+* Handles log rotated files on most operating systems (supports: renamed, truncated & "new file per day" log rotation methods)
 * [Init script is available here](https://github.com/logdna/logdna-agent/blob/master/scripts/init-script) (rpm/deb packages already include this)
-* Agent is self-updating to latest point releases, no need to maintain latest versions (this requires LogDNA YUM/APT repo to be installed)
+* The Agent self-updates to latest point releases. There is no need to maintain the latest versions (this requires that the LogDNA YUM/APT repo be installed)
 ```
 # YUM Repo
 echo "[logdna]
@@ -106,7 +107,7 @@ sudo apt-get update
 
 The LogDNA agent authenticates using your [LogDNA Ingestion Key](https://app.logdna.com/manage/profile) and opens a secure web socket to LogDNA's ingestion servers. It then 'tails' for new log data, as well as watches for new files added to your specific logging directories.
 
-If you don't have a LogDNA account, you can create one on https://logdna.com or if you're on macOS w/[Homebrew](https://brew.sh) installed:
+If you don't have a LogDNA account, you can create one on https://logdna.com. Or if you're using macOS w/[Homebrew](https://brew.sh) installed:
 
 ```
 brew cask install logdna-cli
@@ -116,14 +117,14 @@ logdna register <email>
 
 ## Kubernetes Logging
 
-Set up Kubernetes logging with 2 `kubectl` commands with the LogDNA agent! We extract pertinent Kubernetes metadata: pod name, container name, container id, namespace, and labels etc:
+Set up Kubernetes logging with with the LogDNA Agent using just 2 `kubectl` commands! We extract pertinent Kubernetes metadata including the pod name, container name, container id, namespace, and labels:
 
 ```
 kubectl create secret generic logdna-agent-key --from-literal=logdna-agent-key=<YOUR LOGDNA INGESTION KEY>
 kubectl create -f https://raw.githubusercontent.com/logdna/logdna-agent/master/logdna-agent-ds.yaml
 ```
 
-This automatically installs a logdna-agent pod into each node in your cluster and ships stdout/stderr from all containers, both application logs and node logs. Note: By default, the agent pod will collect logs from all namespaces on each node, including `kube-system`. View your logs at https://app.logdna.com. See [YAML file](https://raw.githubusercontent.com/logdna/logdna-agent/master/logdna-agent-ds.yaml) for additional options such as `LOGDNA_TAGS`.
+This automatically installs a logdna-agent pod into each node in your cluster and ships stdout/stderr from all containers, both application logs and node logs. Note: by default, the agent pod will collect logs from all namespaces on each node, including `kube-system`. View your logs at https://app.logdna.com. See [YAML file](https://raw.githubusercontent.com/logdna/logdna-agent/master/logdna-agent-ds.yaml) for additional options such as `LOGDNA_TAGS`.
 
 ### Upgrading to LogDNA Agent 2.0 for Kubernetes
 
@@ -135,7 +136,7 @@ kubectl patch ds/logdna-agent -p '{"spec":{"updateStrategy":{"type":"RollingUpda
 kubectl patch ds/logdna-agent -p '{"spec":{"template":{"spec":{"containers":[{"name":"logdna-agent","image":"logdna/logdna-agent-v2:stable", "imagePullPolicy": "Always"}]}}}}'
 ```
 
-To confirm it upgraded correctly, please run `kubectl get ds logdna-agent -o yaml | grep "image: logdna/"` and if you see `image: logdna/logdna-agent-v2:stable` then you are good to go.
+To confirm that it upgraded correctly, please run `kubectl get ds logdna-agent -o yaml | grep "image: logdna/"`. If you see `image: logdna/logdna-agent-v2:stable` then you are good to go.
 
 If you'd like to to install LogDNA's Agent 2.0 into a new cluster, you can simply run the following two `kubectl` commands:
 
@@ -145,7 +146,7 @@ kubectl create secret generic logdna-agent-key --from-literal=logdna-agent-key=<
 kubectl create -f https://raw.githubusercontent.com/logdna/logdna-agent/master/logdna-agent-v2.yaml
 ```
 
-If you don't have a LogDNA account, you can create one on https://logdna.com or if you're on macOS w/[Homebrew](https://brew.sh) installed:
+If you don't have a LogDNA account, you can create one at https://logdna.com or if you're on macOS w/[Homebrew](https://brew.sh) installed:
 
 ```
 brew cask install logdna-cli
@@ -177,7 +178,7 @@ Notes:
 
 ### LogDNA Pay-per-gig Pricing
 
-Our [paid plans](https://logdna.com/#pricing) start at $1.50/GB per month, pay for what you use / no fixed data buckets / all paid plans include all features.
+Our [paid plans](https://logdna.com/pricing/) start at $1.50/GB per month. Pay only for what you use, with no fixed data buckets. All paid plans include all features.
 
 ## Contributors
 


### PR DESCRIPTION
Removing bad information about using double quotes in the conf file, clarifying that glob patterns do need double quotes only in the `index.js` cli, fixing a bad URL link, and doing a language cleanup.