### PR TITLE
update user-agent header by adding distro information

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,6 +255,8 @@ if ((os.platform() === 'win32' && require('is-administrator')()) || process.getu
         , (dist, cb) => {
             if (dist && dist.os) {
                 config.osdist = dist.os + (dist.release ? ' ' + dist.release : '');
+                config.DEFAULT_REQ_HEADERS['user-agent'] += ` (${dist.name && dist.name.toLowerCase() || dist.os})`;
+                config.DEFAULT_REQ_HEADERS_GZIP['user-agent'] += ` (${dist.name && dist.name.toLowerCase() || dist.os})`;
             }
 
             return request(config.AWS_INSTANCE_CHECK_URL, {

--- a/index.js
+++ b/index.js
@@ -252,11 +252,12 @@ if ((os.platform() === 'win32' && require('is-administrator')()) || process.getu
 
             return getDistro(DEFAULT_OS_PATH, cb);
         }
-        , (dist, cb) => {
-            if (dist && dist.os) {
-                config.osdist = dist.os + (dist.release ? ' ' + dist.release : '');
-                config.DEFAULT_REQ_HEADERS['user-agent'] += ` (${dist.name && dist.name.toLowerCase() || dist.os})`;
-                config.DEFAULT_REQ_HEADERS_GZIP['user-agent'] += ` (${dist.name && dist.name.toLowerCase() || dist.os})`;
+        , (distro, cb) => {
+            if (distro && distro.os) {
+                config.osdist = distro.os + (distro.release ? ' ' + distro.release : '');
+                const distroInfo = distro.name && distro.name.toLowerCase() || distro.os;
+                config.DEFAULT_REQ_HEADERS['user-agent'] += ` (${distroInfo})`;
+                config.DEFAULT_REQ_HEADERS_GZIP['user-agent'] += ` (${distroInfo})`;
             }
 
             return request(config.AWS_INSTANCE_CHECK_URL, {

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,10 +5,6 @@ const path = require('path');
 // Internal Modules
 const pkg = require('../package.json');
 
-// Constants
-const PKG_SYSTEMS = { linux: '-linux', win32: '-windows', darwin: '-mac' };
-const USER_AGENT = `${pkg.name}${PKG_SYSTEMS[os.platform()] || ''}/${pkg.version}`;
-
 module.exports = {
     AWS_INSTANCE_CHECK_URL: 'http://169.254.169.254/latest/dynamic/instance-identity/document/'
     , BUF_LIMIT: process.env.BUF_LIMIT || 10000 // 10000 lines
@@ -16,8 +12,8 @@ module.exports = {
     , DEFAULT_CONF_FILE: os.platform() !== 'win32' ? '/etc/logdna.conf' : path.join(process.env.ALLUSERSPROFILE, '/logdna/logdna.conf')
     , DEFAULT_HTTP_ERRORS: ['ECONNRESET', 'EHOSTUNREACH', 'ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND']
     , DEFAULT_LOG_PATH: os.platform() !== 'win32' ? '/var/log' : path.join(process.env.ALLUSERSPROFILE, '/logs')
-    , DEFAULT_REQ_HEADERS: { 'Content-Type': 'application/json; charset=UTF-8', 'user-agent': process.env.LDUSERAGENT || USER_AGENT }
-    , DEFAULT_REQ_HEADERS_GZIP: { 'Content-Type': 'application/json; charset=UTF-8', 'Content-Encoding': 'gzip', 'user-agent': process.env.LDUSERAGENT || USER_AGENT }
+    , DEFAULT_REQ_HEADERS: { 'Content-Type': 'application/json; charset=UTF-8', 'user-agent': `${pkg.name}/${pkg.version}` }
+    , DEFAULT_REQ_HEADERS_GZIP: { 'Content-Type': 'application/json; charset=UTF-8', 'Content-Encoding': 'gzip', 'user-agent': `${pkg.name}/${pkg.version}` }
     , DEFAULT_WINTAIL_FILE: os.platform() !== 'win32' ? '/etc/winTail.ps1' : path.join(process.env.ALLUSERSPROFILE, '/logdna/winTail.ps1')
     , FILEQUEUE_PATH: os.platform() !== 'win32' ? (process.env.FILEQUEUE_PATH || '/tmp') : path.join(process.env.ALLUSERSPROFILE, (process.env.FILEQUEUE_PATH || '/tmp'))
     , FLUSH_INTERVAL: process.env.FLUSH_INTERVAL || 250 // 250 millisec


### PR DESCRIPTION
we agreed on having `user-agent` header as in this format: `logdna-agent/1.6.2 (darwin)`, for example.

Reference:
- https://github.com/logdna/logdna-agent/blob/master/test/lib/get-distro.js#L17-L20
- https://github.com/logdna/logdna-agent/blob/master/test/assets/test-getDistro.config