### PR TITLE
Add v2 beta yaml for v1 -> v2 agent transition

### DIFF
--- a/logdna-agent-v2-beta.yaml
+++ b/logdna-agent-v2-beta.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: logdna-agent
+  labels:
+    app: logdna-agent
+spec:
+  selector:
+    matchLabels:
+      app: logdna-agent
+  template:
+    metadata:
+      labels:
+        app: logdna-agent
+    spec:
+      containers:
+      serviceAccountName: logdna-agent
+      - name: logdna-agent
+        image: logdna/logdna-agent:2.1.8-beta
+        imagePullPolicy: Always
+        env:
+        - name: LOGDNA_AGENT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: logdna-agent-key
+              key: logdna-agent-key
+        - name: LOGDNA_PLATFORM
+          value: k8s
+        - name: LOGDNA_TAGS
+          value: agent-v2
+        - name: RUST_LOG
+          value: info
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          requests:
+            cpu: 20m
+          limits:
+            memory: 300Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: vardata
+          mountPath: /var/data
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: mnt
+          mountPath: /mnt
+          readOnly: true
+        - name: osrelease
+          mountPath: /etc/os-release
+        - name: logdnahostname
+          mountPath: /etc/logdna-hostname
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: vardata
+        hostPath:
+          path: /var/data
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: mnt
+        hostPath:
+          path: /mnt
+      - name: osrelease
+        hostPath:
+          path: /etc/os-release
+      - name: logdnahostname
+        hostPath:
+          path: /etc/hostname
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logdna-agent
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: logdna-agent
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list", "create", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get","list", "create", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get","list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: logdna-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logdna-agent
+subjects:
+  - kind: ServiceAccount
+    name: logdna-agent
+    namespace: default


### PR DESCRIPTION
This is intended for testing the latest v2 image, now hosted in the v1 repository. This is not yet 'officially' released as a beta, so use at your own risk. Release messaging for the beta will likely go out later this week.