### PR TITLE
adding tagged build filters so that it will run with the tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,7 @@ workflows:
           channel: "${SLACK_INTEGRATION_NOTIFICATION_CHANNEL_KEY}" # Optional: If set, overrides webhook's default channel setting
           requires:
           - docker-sysdig-scan
+          filters: *tagged_build_filters
       - approve-docker-image:
           type: approval
           requires:


### PR DESCRIPTION
CircleCI will not run workflow steps from git tags without them being explicitly stated, so we need to define the same filter for this step as for the other steps.