### PR TITLE
Added containers to build binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 .dockerignore
 .git
 Dockerfile
+logdna-agent
+node_modules
+package-lock.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,11 @@
 *.Dockerfile
+*.md
 .circleci
 .dockerignore
+.eslintrc
 .git
 Dockerfile
 logdna-agent
+logdna-agent.exe
 node_modules
 package-lock.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.Dockerfile
+.circleci
+.dockerignore
+.git
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ node_modules
 # Some extra data
 package-lock.json
 *~
+logdna-agent
 
 # WebStorm config
 .idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ grunt build
 
 This takes a bit of time and will output a binary at `./logdna-agent` (or `.\logdna-agent.exe` if on Windows). For the initial build, majority of time will be spent building node.js. Subsequent builds will be much faster as node.js would've already been built.
 
-### Docker
+### Via Docker for Linux
 
 To create the binary for Linux via Docker, run:
 
@@ -103,6 +103,19 @@ binary to your local machine, run:
 
     docker create -ti --name logdna-dummy logdna-agent-build sh
     docker cp logdna-dummy:/usr/local/bin/logdna-agent .
+    docker rm -f logdna-dummy
+
+### Via Docker for Windows
+
+To create the binary for Windows via Docker, run:
+
+    docker build -t logdna-agent-windows-build -f windows-build.Dockerfile .
+
+`logdna-agent.exe` will be available in the root directory. To copy the binary
+to your local machine, run:
+
+    docker create -ti --name logdna-dummy logdna-agent-windows-build cmd
+    docker cp logdna-dummy:/logdna-agent.exe .
     docker rm -f logdna-dummy
 
 ## Packaging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,19 @@ grunt build
 
 This takes a bit of time and will output a binary at `./logdna-agent` (or `.\logdna-agent.exe` if on Windows). For the initial build, majority of time will be spent building node.js. Subsequent builds will be much faster as node.js would've already been built.
 
+### Docker
+
+To create the binary for Linux via Docker, run:
+
+    docker build -t logdna-agent-build -f linux-build.Dockerfile .
+
+`logdna-agent` will be available in the `/usr/local/bin` directory. To copy the
+binary to your local machine, run:
+
+    docker create -ti --name logdna-dummy logdna-agent-build sh
+    docker cp logdna-dummy:/coreos-installer .
+    docker rm -f logdna-dummy
+
 ## Packaging
 
 ### Linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ To create the binary for Linux via Docker, run:
 binary to your local machine, run:
 
     docker create -ti --name logdna-dummy logdna-agent-build sh
-    docker cp logdna-dummy:/coreos-installer .
+    docker cp logdna-dummy:/usr/local/bin/logdna-agent .
     docker rm -f logdna-dummy
 
 ## Packaging

--- a/linux-build.Dockerfile
+++ b/linux-build.Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:7
+
+# Install node.js development environment
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - \
+    && yum install -y nodejs \
+    && npm install -g grunt-cli
+
+# Install nexe to package the LogDNA agent as a native executable with the
+# node.js runtime bundled
+RUN npm install -g nexe@1.1.2
+
+# Install build tools
+RUN yum groupinstall -y "Development Tools"
+
+# Install npm dependencies
+COPY package.json /logdna-agent/package.json
+WORKDIR /logdna-agent
+RUN npm install
+
+# Now build the package
+COPY . /logdna-agent
+RUN grunt exec:nexe
+
+# Test that the package is usable
+FROM alpine
+COPY --from=0 /logdna-agent/logdna-agent /usr/local/bin
+RUN logdna-agent --help

--- a/windows-build.Dockerfile
+++ b/windows-build.Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+# Install nodejs
+RUN powershell -Command Invoke-WebRequest -Uri \
+        https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip \
+        -OutFile nvm-noinstall.zip
+RUN powershell -Command Expand-Archive nvm-noinstall.zip
+RUN fsutil file createnew settings.txt 0
+RUN /nvm-noinstall/nvm install 12.9.1
+RUN setx /M PATH "%PATH%;C:\\v12.9.1"
+RUN rename C:\\v12.9.1\\node64.exe node.exe
+
+# Install nexe to package the LogDNA agent as a native executable with the
+# node.js runtime bundled
+RUN npm install -g nexe
+
+# Install npm dependencies
+COPY package.json /logdna-agent/package.json
+WORKDIR /logdna-agent
+RUN npm install
+
+# Build the package
+COPY . /logdna-agent
+RUN nexe index.js
+
+# Test that the package is usable
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+COPY --from=0 /logdna-agent/logdna-agent.exe .
+RUN logdna-agent --help


### PR DESCRIPTION
This makes building binaries a lot more simple and consistent.

I also updated nexe to use a pre-compiled version of nodejs, so it doesn't need to be built from source. This significantly reduces the build time.

Packaging hasn't been updated because the current instructions in `CONTRIBUTING.md` are not working (I believe because `Gruntfile.js` references non-public files in the repository).