### PR TITLE
Bump minor version for rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-agent",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "LogDNA Collector Agent",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Rebuild the agent due to the embedded CA root certificate chain
leading to the *.logdna.com certificate not being valid anymore.
This is due to an expired root certificate [0] and not to any
expired certificate on the LogDNA end.

[0] https://thesslonline.com/blog/sectigo-addtrust-external-ca-root-expiring-may-30-2020