### PR TITLE
Install patched agent version 1.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,28 @@
 FROM ubuntu:16.04
 
-MAINTAINER Lee Liu <lee@logdna.com>
+ARG CA_CERTIFICATES_VERSION=20170717~16.04.2
+ARG CURL_VERSION=7.*
 
-COPY logdna.gpg /etc/
 
-RUN echo "deb http://repo.logdna.com stable main" > /etc/apt/sources.list.d/logdna.list && \
-    apt-key add /etc/logdna.gpg && \
-    apt-get -y update && \
-    apt-get -y install logdna-agent && \
-    apt-get -y upgrade && \
-    rm -rf /var/lib/apt/lists/*
-    
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.url="https://logdna.com"
+LABEL org.label-schema.maintainer="LogDNA <support@logdna.com>"
+LABEL org.label-schema.name="logdna/logdna-agent"
+LABEL org.label-schema.description="LogDNA agent"
+LABEL org.label-schema.vcs-url="https://github.com/logdna/logdna-agent"
+LABEL org.label-schema.vendor="LogDNA Inc."
+LABEL org.label-schema.docker.cmd="docker run logdna/logdna-agent:latest"
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  ca-certificates=${CA_CERTIFICATES_VERSION} \
+  curl=${CURL_VERSION} \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://s3.amazonaws.com/repo.logdna.com/pool/l/lo/logdna-agent_1.6.3_amd64.deb -O && \
+  dpkg -i logdna-agent_1.6.3_amd64.deb && \
+  rm logdna-agent_1.6.3_amd64.deb
+
+
 CMD ["/usr/bin/logdna-agent"]


### PR DESCRIPTION
A new working agent has been released but our apt repo metadata
is not yet updated. So lets install the hard coded version
directly before fixing this properly.