### PR TITLE
update(Dockerfile): revert patch release change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM ubuntu:16.04
 
-ARG CA_CERTIFICATES_VERSION=20170717~16.04.2
-ARG CURL_VERSION=7.*
-
-
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.url="https://logdna.com"
 LABEL org.label-schema.maintainer="LogDNA <support@logdna.com>"
@@ -13,16 +9,13 @@ LABEL org.label-schema.vcs-url="https://github.com/logdna/logdna-agent"
 LABEL org.label-schema.vendor="LogDNA Inc."
 LABEL org.label-schema.docker.cmd="docker run logdna/logdna-agent:latest"
 
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-  ca-certificates=${CA_CERTIFICATES_VERSION} \
-  curl=${CURL_VERSION} \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+COPY logdna.gpg /etc/	
 
-RUN curl -L https://s3.amazonaws.com/repo.logdna.com/pool/l/lo/logdna-agent_1.6.3_amd64.deb -O && \
-  dpkg -i logdna-agent_1.6.3_amd64.deb && \
-  rm logdna-agent_1.6.3_amd64.deb
-
+RUN echo "deb http://repo.logdna.com stable main" > /etc/apt/sources.list.d/logdna.list && \	
+    apt-key add /etc/logdna.gpg && \	
+    apt-get -y update && \	
+    apt-get -y install logdna-agent && \	
+    apt-get -y upgrade && \	
+    rm -rf /var/lib/apt/lists/*	
 
 CMD ["/usr/bin/logdna-agent"]


### PR DESCRIPTION
During the big incident, we had to come up with [the quick solution](https://github.com/logdna/logdna-agent/pull/174) for building Docker image as fast as possible and for that we had to modify and hardcode the Dockerfile. This Pull Request makes sure things are back to the proper state.

In the long term, we are going to deprecate the K8s version of this Node.js-based Agent but for now let's keep this in this way.

Semver: patch