### PR TITLE
fix(networkInterface): make sure to check `networkInterface` is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix globbing issue [#126](https://github.com/logdna/logdna-agent/pull/126)
 - Fix configuration-related bugs [#130](https://github.com/logdna/logdna-agent/pull/130)
+- Make sure to check `networkInterface` is defined [#185](https://github.com/logdna/logdna-agent/pull/185)
 
 ## [1.6.1] - July 19, 2019
 ### Added

--- a/index.js
+++ b/index.js
@@ -277,8 +277,10 @@ if ((os.platform() === 'win32' && require('is-administrator')()) || process.getu
                 interface.address.startsWith('192.168.'));
         })[0];
 
-        if (networkInterface.mac) { config.mac = networkInterface.mac; }
-        if (networkInterface.address) { config.ip = networkInterface.address; }
+        if (networkInterface) {
+            if (networkInterface.mac) { config.mac = networkInterface.mac; }
+            if (networkInterface.address) { config.ip = networkInterface.address; }
+        }
 
         utils.log(`${config.package} started on ${config.hostname} (${config.ip})`);
         if (config.platform && config.platform.startsWith('k8s')) { k8s.init(); }


### PR DESCRIPTION
This is one of the potential bugs, at least, one of the customers has already reported. The test coverage is going to be added later in different Pull Request.

Semver: patch