### PR TITLE
Don't check for root user when program.config isset

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ commander
   })
 
 function loadConfig(program, uid) {
-  if ((os.platform() === 'win32' && require('is-administrator')()) || uid <= 0) {
+  if (program.config || (os.platform() === 'win32' && require('is-administrator')()) || uid <= 0) {
     const conf_file = program.config || config.DEFAULT_CONF_FILE
     debug(`Path to Configuration File: ${conf_file}`)
     async.waterfall([


### PR DESCRIPTION
If a user defines a program.config, there is really no need to check the root user. We can assume the user wants to put the config in a folder that is not /etc. no?
I don't see any other reason to have the index.js file check for root.