### PR TITLE
bump: release LogDNA Agent v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.5] - August 21, 2020
 ### Changed
 - Update internal logging [#164](https://github.com/logdna/logdna-agent/pull/164)
 
@@ -231,7 +233,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor agent code
 - Lint & Style Validations
 
-[Unreleased]: https://github.com/logdna/logdna-agent/compare/1.6.2...HEAD
+[Unreleased]: https://github.com/logdna/logdna-agent/compare/1.6.5...HEAD
+[1.6.5]: https://github.com/logdna/logdna-agent/compare/1.6.2...1.6.5
 [1.6.2]: https://github.com/logdna/logdna-agent/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/logdna/logdna-agent/compare/1.5.6...1.6.1
 [1.5.6]: https://github.com/logdna/logdna-agent/compare/1.5.5...1.5.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-agent",
-  "version": "1.6.3",
+  "version": "1.6.5",
   "description": "LogDNA Collector Agent",
   "main": "index.js",
   "scripts": {

--- a/tools/files/darwin/logdna-agent.rb
+++ b/tools/files/darwin/logdna-agent.rb
@@ -1,5 +1,5 @@
 cask 'logdna-agent' do
-  version '1.6.2'
+  version '1.6.5'
   sha256 '350956cbeddf0f0b1cf991a58d659e2a4c2344b621370e10c8adb950f9c6bc47'
 
   # github.com/logdna/logdna-agent was verified as official when first introduced to the cask

--- a/tools/files/win32/logdna-agent.nuspec
+++ b/tools/files/win32/logdna-agent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>logdna-agent</id>
     <title>LogDNA Agent for Windows</title>
-    <version>1.6.3</version>
+    <version>1.6.5</version>
     <authors>smusali,leeliu</authors>
     <owners>leeliu</owners>
     <summary>LogDNA Agent for Windows</summary>


### PR DESCRIPTION
## CHANGELOG

### Changed
- Update internal logging [#164](https://github.com/logdna/logdna-agent/pull/164)

### Fixed
- Fix stringification issue on handling 207 [#152](https://github.com/logdna/logdna-agent/pull/152)
- Fix memory leak issue [#157](https://github.com/logdna/logdna-agent/pull/157)
- Make sure `process.getuid` doesn't get called on `Windows` [#188](https://github.com/logdna/logdna-agent/pull/188)

Ref: LOG-6016
Semver: patch