### PR TITLE
fix: General fixes prior to releasing v1, 2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ function loadConfig(program) {
       config = {
         ...config
       , ...parsedConfig
-      , tags: process.env.LOGDNA_TAGS || config.tags
+      , tags: process.env.LOGDNA_TAGS || parsedConfig.tags
       , healthcheckTimer: null
       , rescanTimer: null
       }
@@ -276,7 +276,7 @@ function loadConfig(program) {
       if (networkInterface.address) { config.ip = networkInterface.address }
     }
 
-    utils.log(`${config.package} started on ${config.hostname} (${config.ip})`)
+    utils.log(`Agent started on ${config.hostname} (${config.ip})`)
     if (config.userAgent) {
       config.DEFAULT_REQ_HEADERS['user-agent'] = config.userAgent
       config.DEFAULT_REQ_HEADERS_GZIP['user-agent'] = config.userAgent

--- a/lib/logger-client.js
+++ b/lib/logger-client.js
@@ -17,7 +17,7 @@ function createLoggerClient(config) {
   logger = createLogger(config.key, {
     payloadStructure: 'agent'
   , url: config.LOGDNA_URL
-  , hostname: config.hostname.replace(/[^a-zA-Z0-9]/g, '') // Satisfy hostname regex in the client
+  , hostname: config.hostname.replace(/[^a-zA-Z0-9.-]/g, '') // Satisfy hostname regex in the client
   , mac: config.mac
   , ip: config.ip
   , tags: config.tags


### PR DESCRIPTION
* Tags were not being passed to the client due to an
  incorrect variable name.
* A log entry had a blank `config.package`.  Removed.
* The `hostname` regex was too strict.  Added dots and dashes.

Semver: patch
Ref: LOG-7387