### PR TITLE
config: upgrade node version to v12.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# logdna-agent
+# LogDNA Agent
 
-[![Build Status](https://travis-ci.org/logdna/logdna-agent.svg?branch=master)](https://travis-ci.org/logdna/logdna-agent)
-[![Build status](https://ci.appveyor.com/api/projects/status/mk5rb0uk6xkjxhk2/branch/master?svg=true)](https://ci.appveyor.com/project/mikehu/logdna-agent/branch/master)
-
-LogDNA's collector agent which streams log files to your LogDNA account. LogDNA is a hosted, cloud logging service.
+LogDNA Agent streams from log files to your LogDNA account. Works with Linux, Windows, and macOS Servers.
 
 ## Getting Started
 

--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ function loadConfig(program) {
       if (networkInterface.address) { config.ip = networkInterface.address }
     }
 
-    utils.log(`Agent started on ${config.hostname} (${config.ip})`)
+    utils.log(`${pkg.name}/${pkg.version} started on ${config.hostname} (${config.ip})`)
     if (config.userAgent) {
       config.DEFAULT_REQ_HEADERS['user-agent'] = config.userAgent
       config.DEFAULT_REQ_HEADERS_GZIP['user-agent'] = config.userAgent

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logdna-agent",
   "version": "1.6.5",
-  "description": "LogDNA Collector Agent",
+  "description": "LogDNA Agent streams from log files to your LogDNA account. Works with Linux, Windows, and macOS Servers",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
@@ -36,11 +36,9 @@
   },
   "dependencies": {
     "@logdna/logger": "^1.3.2",
-    "agentkeepalive": "^4.1.0",
     "async": "^3.2.0",
     "commander": "^4.1.1",
     "debug": "^4.1.1",
-    "file-queue": "^0.3.0",
     "getos": "^3.1.4",
     "glob": "^7.1.6",
     "is-administrator": "^1.0.1",

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,7 +10,7 @@
 LogDNA Agent can be built and released for Debian systems by running the `scripts/debian.sh` script: `bash tools/scripts/debian.sh`. Versioning for Linux Systems is tracked using [`package.json`](../package.json#L3).
 
 ### Dependencies
-- `Node.js: v8.3.0` and `NPM: v5.3.0`
+- `Node.js: v12.16.2` and `NPM: v6.14.4`
 - `NEXE: v3.3.3` by `npm install -g nexe@3.3.3`
 - `fpm` by `sudo gem install --no-document fpm`
 - `ghr` by `go get -u github.com/tcnksm/ghr`
@@ -53,7 +53,7 @@ LogDNA Agent can be built and released for RedHat systems by running the `script
 LogDNA Agent can be built and released for Darwin systems by running the `scripts/darwin.sh` script from the project directory: `bash tools/scripts/darwin.sh`. Versioning for Darwin Systems is tracked using [`logdna-agent.rb`](./files/darwin/logdna-agent.rb#L2).
 
 ### Dependencies
-- `Node.js: v8.3.0` and `NPM: v5.3.0`
+- `Node.js: v12.16.2` and `NPM: v6.14.4`
 - `NEXE: v3.3.3` by `npm install -g nexe@3.3.3`
 - `fpm` by `sudo gem install --no-document fpm`
 - `ghr` by `brew install ghr`
@@ -76,7 +76,7 @@ LogDNA Agent can be built and released for Win32 systems by running the `scripts
 ### Dependencies
 - `choco` by `iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))` on `PowerShell`
 - `nssm` by `choco install -y nssm`
-- `Node.js: v8.3.0` and `NPM: v5.3.0` by `choco install nodejs --version=8.3.0`
+- `Node.js: v12.16.2` and `NPM: v6.14.4`
 - `NEXE: v3.3.3` by `npm install -g nexe@3.3.3`
 - `ghr` by `go get -u github.com/tcnksm/ghr`
 

--- a/tools/files/win32/logdna-agent.nuspec
+++ b/tools/files/win32/logdna-agent.nuspec
@@ -8,7 +8,7 @@
     <authors>smusali,leeliu</authors>
     <owners>leeliu</owners>
     <summary>LogDNA Agent for Windows</summary>
-    <description>LogDNA Collector Agent Streaming File Logs to LogDNA.</description>
+    <description>LogDNA Agent streams from log files to your LogDNA account.</description>
     <projectUrl>https://logdna.com/</projectUrl>
     <projectSourceUrl>https://github.com/logdna/logdna-agent</projectSourceUrl>
     <packageSourceUrl>https://github.com/logdna/logdna-agent</packageSourceUrl>

--- a/tools/scripts/darwin.sh
+++ b/tools/scripts/darwin.sh
@@ -5,12 +5,12 @@
 ARCH=x64
 INPUT_TYPE=dir
 LICENSE=MIT
-NODE_VERSION=8.3.0 # Will upgrade after 1.6.5
+NODE_VERSION=12.16.2
 OSXPKG_IDENTIFIER_PREFIX=com.logdna
 OUTPUT_TYPE=osxpkg
 PACKAGE_NAME=logdna-agent
 S3_BUCKET=repo.logdna.com
-VERSION=$(cat tools/files/darwin/logdna-agent.rb | grep "version '" | cut -d"'" -f2)
+VERSION=$(cat tools/files/darwin/logdna-agent.rb | grep "version \"" | cut -d"\"" -f2)
 
 # PAUSE FUNCTION
 function pause(){
@@ -58,7 +58,7 @@ sed "s/${OLDSHA256CHECKSUM}/${SHA256CHECKSUM}/" ../tools/files/darwin/logdna-age
 cd ..
 
 # STEP 4: RELEASE
-ghr -draft \
+ghr \
 	-n "LogDNA Agent v${VERSION}" \
 	-r ${PACKAGE_NAME} \
 	-u logdna \

--- a/tools/scripts/debian.sh
+++ b/tools/scripts/debian.sh
@@ -6,7 +6,7 @@ ARCH=x64
 DEB_SIGNATURE_ID=EF506BE8
 INPUT_TYPE=dir
 LICENSE=MIT
-NODE_VERSION=8.3.0 # Will upgrade after 1.6.5
+NODE_VERSION=12.16.2
 OUTPUT_TYPE=deb
 PACKAGE_NAME=logdna-agent
 S3_BUCKET=repo.logdna.com
@@ -52,7 +52,7 @@ mv *.deb ../.pkg/
 cd ..
 
 # STEP 3: RELEASE
-ghr -draft \
+ghr \
 	-n "LogDNA Agent v${VERSION}" \
 	-r ${PACKAGE_NAME} \
 	-u logdna \

--- a/tools/scripts/redhat.sh
+++ b/tools/scripts/redhat.sh
@@ -5,7 +5,7 @@
 ARCH=x64
 INPUT_TYPE=dir
 LICENSE=MIT
-NODE_VERSION=8.3.0 # Will upgrade after 1.6.5
+NODE_VERSION=8.3.0
 OUTPUT_TYPE=rpm
 PACKAGE_NAME=logdna-agent
 S3_BUCKET=repo.logdna.com
@@ -17,7 +17,7 @@ function pause(){
 }
 
 # PREPARE FOLDER AND FILES
-mkdir -p .build/
+mkdir -p .build/ .pkg/
 cp \
 	tools/files/linux/before-remove \
 	tools/files/linux/after-upgrade \
@@ -51,7 +51,7 @@ mv *.rpm ../.pkg/
 cd ..
 
 # STEP 3: RELEASE
-${HOME}/go/bin/ghr -draft \
+${HOME}/go/bin/ghr \
 	-n "LogDNA Agent v${VERSION}" \
 	-r ${PACKAGE_NAME} \
 	-u logdna \

--- a/tools/scripts/win32.sh
+++ b/tools/scripts/win32.sh
@@ -3,7 +3,7 @@
 
 # VARIABLES
 ARCH=x64
-NODE_VERSION=8.3.0 # Will upgrade after 1.6.5
+NODE_VERSION=12.16.2
 PACKAGE_NAME=logdna-agent
 VERSION=$(cat tools/files/win32/logdna-agent.nuspec | grep "<version>" | cut -d'>' -f2 | cut -d'<' -f1)
 
@@ -33,7 +33,7 @@ cd ..
 cp .build/*.nupkg .build/tools/*.exe .pkg/
 
 # STEP 3: RELEASE
-ghr -draft \
+ghr \
 	-n "LogDNA Agent v${VERSION}" \
 	-r ${PACKAGE_NAME} \
 	-u logdna \


### PR DESCRIPTION
After fully testing on supported OS versions, we have decided to upgrade the node version to v12.16.2 for MacOSX, Windows, and Debian Systems. This Pull Request contains some small improvements and fixes
too.

Ref: LOG-7309
Semver: major