### PR TITLE
bump: bump the version to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - October 2, 2020
 ### Removed
 - Deprecate the unstable WinEvent Logging component [#194](https://github.com/logdna/logdna-agent/pull/194)
+- Remove Kubernetes support [#196](https://github.com/logdna/logdna-agent/pull/196)
+
+### Changed
+- Use the node client for logging [#195](https://github.com/logdna/logdna-agent/pull/195)
+- Use `eslint-config-logdna` from NPM [#198](https://github.com/logdna/logdna-agent/pull/198)
+- Upgrade node version to `12.16.2` [#199](https://github.com/logdna/logdna-agent/pull/199)
 
 ## [1.6.5] - August 21, 2020
 ### Changed
@@ -235,7 +243,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor agent code
 - Lint & Style Validations
 
-[Unreleased]: https://github.com/logdna/logdna-agent/compare/1.6.5...HEAD
+[Unreleased]: https://github.com/logdna/logdna-agent/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/logdna/logdna-agent/compare/1.6.5...2.0.0
 [1.6.5]: https://github.com/logdna/logdna-agent/compare/1.6.2...1.6.5
 [1.6.2]: https://github.com/logdna/logdna-agent/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/logdna/logdna-agent/compare/1.5.6...1.6.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-agent",
-  "version": "1.6.5",
+  "version": "2.0.0",
   "description": "LogDNA Agent streams from log files to your LogDNA account. Works with Linux, Windows, and macOS Servers",
   "main": "index.js",
   "scripts": {

--- a/tools/files/darwin/logdna-agent.rb
+++ b/tools/files/darwin/logdna-agent.rb
@@ -1,6 +1,6 @@
 cask "logdna-agent" do
-  version "1.6.5"
-  sha256 "350956cbeddf0f0b1cf991a58d659e2a4c2344b621370e10c8adb950f9c6bc47"
+  version "2.0.0"
+  sha256 "fa6039599c9d3fcb6c33b69c95b7e86bd88261db0d3a73076ea2887876423ded"
 
   # github.com/logdna/logdna-agent/ was verified as official when first introduced to the cask
   url "https://github.com/logdna/logdna-agent/releases/download/#{version}/logdna-agent-#{version}.pkg"

--- a/tools/files/win32/VERIFICATION.txt
+++ b/tools/files/win32/VERIFICATION.txt
@@ -10,7 +10,7 @@ To verify logdna-agent.exe:
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum: 9daf22c15f4f42e8c7ac4cdf73c26f7154d325d0defe14ece18d1203a9c7afd1
+  checksum: 0B44C47558B1BAF207AD3D9A8D93A37422E96877319BCB4A0A4ED78B3CA626B8
  
 This package is published by LogDNA. You can build a binary directly
 by following the instructions here:

--- a/tools/files/win32/logdna-agent.nuspec
+++ b/tools/files/win32/logdna-agent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>logdna-agent</id>
     <title>LogDNA Agent for Windows</title>
-    <version>1.6.5</version>
+    <version>2.0.0</version>
     <authors>smusali,leeliu</authors>
     <owners>leeliu</owners>
     <summary>LogDNA Agent for Windows</summary>


### PR DESCRIPTION
- Deprecate the unstable WinEvent Logging component [#194]
- Remove Kubernetes support [#196]
- Use the node client for logging [#195]
- Use `eslint-config-logdna` from NPM [#198]
- Upgrade node version to `12.16.2` [#199]