### PR TITLE
fix: Add missing exclude_regex logic

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -15,6 +15,6 @@ coverage-report:
 files:
 - test/**/*.js
 statements: 71
-branches: 58
+branches: 57
 functions: 77
 lines: 71

--- a/lib/file-utilities.js
+++ b/lib/file-utilities.js
@@ -102,16 +102,17 @@ function getFiles(config, dir, callback) {
 
 function streamFiles(config, logfiles, callback) {
   logfiles.forEach((file) => {
-    let tail, i
+    let tail
 
     if (os.platform() !== 'win32' && config.TAIL_MODE === 'unix') {
       debug('tailing: ' + file)
       tail = spawn('tail', ['-n0', '-F', file])
       tail.stdout.on('data', (data) => {
         const lines = data.toString().trim().split('\n')
-        for (i = 0; i < lines.length; i++) {
+        for (const line of lines) {
+          if (config.exclude_regex && config.exclude_regex.test(line)) continue
           client.log.agentLog({
-            line: lines[i]
+            line
           , f: file
           })
         }
@@ -128,6 +129,7 @@ function streamFiles(config, logfiles, callback) {
       tail = TailReadStream.tail(file, config)
       tail.pipe(new Splitter())
         .on('data', (line) => {
+          if (config.exclude_regex && config.exclude_regex.test(line)) return
           client.log.agentLog({
             line
           , f: file

--- a/test/integration/start.js
+++ b/test/integration/start.js
@@ -10,7 +10,7 @@ const fileUtilities = require('../../lib/file-utilities.js')
 
 nock.disableNetConnect()
 
-test('start() calls healthcheck and tails a log', (t) => {
+test('start() creates a client logger and tails a log', (t) => {
   t.plan(2)
   t.on('end', () => {
     nock.cleanAll()
@@ -67,5 +67,73 @@ test('start() calls healthcheck and tails a log', (t) => {
 
   setTimeout(async () => {
     await fs.promises.appendFile(logPath, 'Here is my line1\nHere is my line 2\n', 'utf8')
+  }, 500)
+})
+
+test('exclude_regex successfully ignores lines', (t) => {
+  t.plan(2)
+  t.on('end', () => {
+    nock.cleanAll()
+    fileUtilities.gracefulShutdown()
+  })
+
+  const logname = 'regex-testing.log'
+  const tempDir = t.testdir({
+    [logname]: ''
+  })
+  const logPath = path.join(tempDir, logname)
+
+  const config = {
+    ...constants
+  , hostname: 'MyHostMachine'
+  , UserAgent: 'logdna-agent/1.6.5 (darwin)'
+  , mac: '3c:22:fb:27:72:f5'
+  , ip: '192.168.1.9'
+  , COMPRESS: false
+  , logdir: [tempDir]
+  , key: '<MY KEY HERE>'
+  , exclude_regex: /\bNOPE\b/
+  }
+
+  nock(config.LOGDNA_URL)
+    .post(/.*/, (body) => {
+      const expected = {
+        e: 'ls'
+      , ls: [
+          {
+            line: 'This line is good'
+          , f: logPath
+          }
+        , {
+            line: 'Good also'
+          , f: logPath
+          }
+        , {
+            line: 'Good because of boundary failure with xNOPEx'
+          , f: logPath
+          }
+        ]
+      }
+      t.match(body, expected, 'Ingester POST body is correct')
+      return true
+    })
+    .query((qs) => {
+      t.match(qs, {
+        hostname: config.hostname
+      , ip: config.ip
+      , mac: config.mac
+      , tags: ''
+      }, 'Ingester POST QUERY_STRING is correct')
+      return true
+    })
+    .reply(200, 'Ingested')
+
+  start(config)
+
+  setTimeout(async () => {
+    const lines = 'This line is good\nThis line is NOPE\nGood also\n'
+      + 'Good because of boundary failure with xNOPEx\nAnd NOPE way this is good'
+
+    await fs.promises.appendFile(logPath, lines, 'utf8')
   }, 500)
 })


### PR DESCRIPTION
A previous refactor accidentally removed the code to
ignore lines that match a specific pattern.

Semver: patch
Ref: LOG-7472