### PR TITLE
fix: Revert environment variable changes

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -14,7 +14,7 @@ coverage-report:
 - html
 files:
 - test/**/*.js
-statements: 70
+statements: 69
 branches: 57
 functions: 74
-lines: 70
+lines: 69

--- a/.taprc
+++ b/.taprc
@@ -14,7 +14,7 @@ coverage-report:
 - html
 files:
 - test/**/*.js
-statements: 71
+statements: 70
 branches: 57
-functions: 77
-lines: 71
+functions: 74
+lines: 70

--- a/lib/build-logger-url.js
+++ b/lib/build-logger-url.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const {log} = require('./utils.js')
+
+module.exports = function buildLoggerURL(config) {
+  const {
+    LOGDNA_LOGSSL: ssl
+  , LOGDNA_LOGHOST: host
+  , LOGDNA_LOGPORT: port
+  , LOGDNA_LOGENDPOINT: endpoint
+  } = config
+
+  const protocol = ssl
+    ? 'https'
+    : 'http'
+
+  const url = `${protocol}://${host}:${port}${endpoint}`
+
+  log(`LogDNA URL: ${url}`, 'info')
+
+  return url
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,10 +13,13 @@ module.exports = {
 , FILEQUEUE_PATH: os.platform() !== 'win32'
     ? (process.env.FILEQUEUE_PATH || '/tmp')
     : path.join(process.env.ALLUSERSPROFILE, (process.env.FILEQUEUE_PATH || '/tmp'))
-, FLUSH_INTERVAL: process.env.FLUSH_INTERVAL
+, FLUSH_INTERVAL: process.env.FLUSH_INTERVAL || 1000
 , FLUSH_LIMIT: process.env.FLUSH_LIMIT
 , PROXY: process.env.HTTPS_PROXY || process.env.HTTP_PROXY
-, LOGDNA_URL: process.env.LOGDNA_URL || 'https://logs.logdna.com/logs/agent'
+, LOGDNA_LOGENDPOINT: process.env.LDLOGPATH || process.env.INGESTION_ENDPOINT || '/logs/agent'
+, LOGDNA_LOGHOST: process.env.LDLOGHOST || process.env.INGESTION_HOST || 'logs.logdna.com'
+, LOGDNA_LOGPORT: process.env.LDLOGPORT || process.env.INGESTION_PORT || 443
+, LOGDNA_LOGSSL: isNaN(process.env.LDLOGSSL) ? true : +process.env.LDLOGSSL
 , RESCAN_INTERVAL: process.env.RESCAN_INTERVAL || 60000 // 1 min
 , RESCAN_INTERVAL_K8S: process.RESCAN_INTERVAL_K8S || 10000 // 10 sec
 , SOCKET_PATH: process.env.LOGDNA_DOCKER_SOCKET || process.env.DOCKER_SOCKET || '/var/run/docker.sock'

--- a/lib/logger-client.js
+++ b/lib/logger-client.js
@@ -2,6 +2,8 @@
 
 const {createLogger} = require('@logdna/logger')
 const {log} = require('./utils.js')
+const buildLoggerURL = require('./build-logger-url.js')
+
 let logger
 
 module.exports = {
@@ -12,11 +14,9 @@ module.exports = {
 }
 
 function createLoggerClient(config) {
-  log(`LogDNA URL: ${config.LOGDNA_URL}`, 'info')
-
   logger = createLogger(config.key, {
     payloadStructure: 'agent'
-  , url: config.LOGDNA_URL
+  , url: buildLoggerURL(config)
   , hostname: config.hostname.replace(/[^a-zA-Z0-9.-]/g, '') // Satisfy hostname regex in the client
   , mac: config.mac
   , ip: config.ip

--- a/lib/tailreadstream/tailreadstream.js
+++ b/lib/tailreadstream/tailreadstream.js
@@ -10,7 +10,7 @@ const Readable = require('stream').Readable
 const config = require('../config')
 
 const DOES_NOT_EXIST_ERROR = 'ENOENT'
-
+const FILE_LOCKED_ERROR = 'EBUSY'
 
 class TailReadStream extends Readable {
   constructor(filepath, options) {
@@ -159,6 +159,13 @@ class TailReadStream extends Readable {
         this.emit('rename')
         this._offset = 0 // reset on rename
       }
+      this._idle += this._interval
+      this._retryInInterval()
+      return
+    }
+
+    if (error.code === FILE_LOCKED_ERROR) {
+      debug(`${this._filepath}: file locked, waiting for it to be released...`)
       this._idle += this._interval
       this._retryInInterval()
       return

--- a/test/integration/start.js
+++ b/test/integration/start.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const constants = require('../../lib/config.js')
 const start = require('../../lib/start.js')
 const fileUtilities = require('../../lib/file-utilities.js')
+const buildLoggerURL = require('../../lib/build-logger-url.js')
 
 nock.disableNetConnect()
 
@@ -34,7 +35,7 @@ test('start() creates a client logger and tails a log', (t) => {
   , key: '<MY KEY HERE>'
   }
 
-  nock(config.LOGDNA_URL)
+  nock(buildLoggerURL(config))
     .post(/.*/, (body) => {
       const expected = {
         e: 'ls'
@@ -95,7 +96,7 @@ test('exclude_regex successfully ignores lines', (t) => {
   , exclude_regex: /\bNOPE\b/
   }
 
-  nock(config.LOGDNA_URL)
+  nock(buildLoggerURL(config))
     .post(/.*/, (body) => {
       const expected = {
         e: 'ls'


### PR DESCRIPTION
Previously, we attempted to move to a single URL
for the logger client and remove the many env vars
that previously "built" the URL.  However, doing a `major`
release for this wasn't sufficient enough to not break
customers, so we are putting them back until such time
we can ensure a safer upgrade path for such breaking
changes.

Semver: patch
Fixes: https://github.com/logdna/logdna-agent/issues/206
Ref: LOG-7618

----------------
feat: Retry reading when file is locked
    
This fixes a bug in the Windows version when applications have the
file open and obtain a lock. The solution is simply to wait until 
the process has released the lock and read again.
    
Fixes: https://github.com/logdna/logdna-agent/issues/167
Semver: patch