### PR TITLE
fix(TailReadStream): Cancel timers to prevent shutdown hanging

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,6 @@ function loadConfig(program) {
         ...config
       , ...parsedConfig
       , tags: process.env.LOGDNA_TAGS || parsedConfig.tags
-      , healthcheckTimer: null
       , rescanTimer: null
       }
 

--- a/lib/file-utilities.js
+++ b/lib/file-utilities.js
@@ -273,7 +273,6 @@ function streamAllLogs(config, callback) {
 
 function gracefulShutdown(signal) {
   log(`got ${signal} signal, shutting down...`)
-  clearTimeout(conf.healthcheckTimer)
   clearTimeout(conf.rescanTimer)
 
   tails.forEach((tail) => {

--- a/lib/tailreadstream/tailreadstream.js
+++ b/lib/tailreadstream/tailreadstream.js
@@ -35,6 +35,10 @@ class TailReadStream extends Readable {
     this._paused = false
     this._ended = false
     this._watching = false
+    this._exiting = false
+    this._retryTimer = null
+    this._watchTimer = null
+    this._readTimer = null
   }
 
   static tail(filepath, fromstart, options) {
@@ -65,6 +69,10 @@ class TailReadStream extends Readable {
   set timeout(timeout) { this._timeout = timeout }
 
   _destroy() {
+    this._exiting = true
+    clearTimeout(this._retryTimer)
+    clearTimeout(this._watchTimer)
+    clearTimeout(this._readTimer)
     this.readable = false
     this._stream = null
     this.timeout = 0
@@ -105,6 +113,8 @@ class TailReadStream extends Readable {
   _getFileSizeAndReadUntilEof() {
     var that = this
 
+    if (this._exiting) return
+
     fs.stat(this._filepath, (err, stats) => {
       if (err) {
         that.readable = false
@@ -118,7 +128,7 @@ class TailReadStream extends Readable {
 
         if (err.code === DOES_NOT_EXIST_ERROR) {
           debug(`${that._filepath}: file does not exist, waiting for it to appear...`)
-          setTimeout(that._getFileSizeAndReadUntilEof.bind(that), that._interval)
+          this._readTimer = setTimeout(that._getFileSizeAndReadUntilEof.bind(that), that._interval)
           that._idle += that._interval
           return
         }
@@ -139,7 +149,8 @@ class TailReadStream extends Readable {
   }
 
   _retryInInterval() {
-    setTimeout(this._readFromOffsetUntilEof.bind(this), this._interval)
+    if (this._exiting) return
+    this._retryTimer = setTimeout(this._readFromOffsetUntilEof.bind(this), this._interval)
   }
 
   _handleError(error) {
@@ -210,14 +221,15 @@ class TailReadStream extends Readable {
   _watchFile() {
     var that = this
 
-    if (!this.readable) {
+    if (this._exiting || !this.readable) {
       this._watching = false
       return
     }
 
     fs.stat(this._filepath, (err, stats) => {
       if (err) {
-        return setTimeout(that._watchFile.bind(that), that._watchinterval)
+        this._watchTimer = setTimeout(that._watchFile.bind(that), that._watchinterval)
+        return
       }
 
       if (stats.size < that._offset) {
@@ -231,7 +243,7 @@ class TailReadStream extends Readable {
         }
       }
 
-      setTimeout(that._watchFile.bind(that), that._watchinterval)
+      this._watchTimer = setTimeout(that._watchFile.bind(that), that._watchinterval)
     })
   }
 }


### PR DESCRIPTION
There was an issue when running the agent as a service where the timers
in `TailReadStream` were hanging the node process. This might be a
difference between the `nexe` binary version and the plain version
(since this issue is not seen when running via node.js directly).
This change adds tracking for all timers in that code, and issues a
`cancelTimeout` for each of them during shutdown. The problem was
verified/reproduced and fixed using a Docker image of Debian.

NOTE: There is currently no test in the test suite that can verify this
change since it already shuts down properly there. Future versions of
the agent will, however, include proper testing and will not be using
`TailReadStream` for file consumption.

Semver: patch
Ref: LOG-7930
Fixes: https://github.com/logdna/logdna-agent/issues/212