### PR TITLE
bump: release LogDNA Agent v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
+## [2.1.1] - November 12, 2020
+### Fixed
+- Cancel timers to prevent shutdown hanging [#215](https://github.com/logdna/logdna-agent/pull/215)
+
+## [2.1.0] - November 2, 2020
 ### Changed
 - Use systemd service name as the app name [#210](https://github.com/logdna/logdna-agent/pull/210)
 
@@ -250,7 +254,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor agent code
 - Lint & Style Validations
 
-[Unreleased]: https://github.com/logdna/logdna-agent/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/logdna/logdna-agent/compare/2.1.1...HEAD
+[2.1.1]: https://github.com/logdna/logdna-agent/compare/2.1.0...2.1.1
+[2.1.0]: https://github.com/logdna/logdna-agent/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/logdna/logdna-agent/compare/1.6.5...2.0.0
 [1.6.5]: https://github.com/logdna/logdna-agent/compare/1.6.2...1.6.5
 [1.6.2]: https://github.com/logdna/logdna-agent/compare/1.6.1...1.6.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-agent",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "LogDNA Agent streams from log files to your LogDNA account. Works with Linux, Windows, and macOS Servers",
   "main": "index.js",
   "scripts": {

--- a/tools/files/darwin/logdna-agent.rb
+++ b/tools/files/darwin/logdna-agent.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 cask "logdna-agent" do
-  version "2.1.0"
-  sha256 "fa6039599c9d3fcb6c33b69c95b7e86bd88261db0d3a73076ea2887876423ded"
+  version "2.1.1"
+  sha256 "235e3fbe1f8899ac6cd0bfe7433dd3c3d254228654e320ff26cc5e710a35b860"
 
   # github.com/logdna/logdna-agent/ was verified as official when first introduced to the cask
   url "https://github.com/logdna/logdna-agent/releases/download/#{version}/logdna-agent-#{version}.pkg"
   appcast "https://github.com/logdna/logdna-agent/releases.atom"
   name "LogDNA Agent"
+  desc "Agent streams from log files to your LogDNA account"
   homepage "https://logdna.com/"
 
   pkg "logdna-agent-#{version}.pkg"

--- a/tools/files/win32/logdna-agent.nuspec
+++ b/tools/files/win32/logdna-agent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>logdna-agent</id>
     <title>LogDNA Agent for Windows</title>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <authors>smusali,leeliu</authors>
     <owners>leeliu</owners>
     <summary>LogDNA Agent for Windows</summary>


### PR DESCRIPTION
### Fixed
- Cancel timers to prevent shutdown hanging [#215](https://github.com/logdna/logdna-agent/pull/215)