### PR TITLE
bump: bump @logdna/logger-node to 2.2.2 and logdna-agent to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - January 28, 2021
+- Bump @logdna/logger which includes user-agent and validation fixes [#222](https://github.com/logdna/logdna-agent/pull/222)
+
 ## [2.2.0] - January 19, 2021
 ### Changed
-- Bump @logdna/logger which includes an `axios` fix for a SSRF vulerability. This bump
-  also includes a passthrough for the `sendUserAgent` option. [#219](https://github.com/logdna/logdna-agent/pull/219)
+- Bump @logdna/logger which includes an `axios` fix for a SSRF vulerability and a passthrough for the `sendUserAgent` option [#219](https://github.com/logdna/logdna-agent/pull/219)
 
 ## [2.1.2] - November 16, 2020
 ### Fixed
@@ -263,7 +265,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor agent code
 - Lint & Style Validations
 
-[Unreleased]: https://github.com/logdna/logdna-agent/compare/2.2.0...HEAD
+[Unreleased]: https://github.com/logdna/logdna-agent/compare/2.2.1...HEAD
+[2.2.1]: https://github.com/logdna/logdna-agent/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/logdna/logdna-agent/compare/2.1.2...2.2.0
 [2.1.2]: https://github.com/logdna/logdna-agent/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/logdna/logdna-agent/compare/2.1.0...2.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-agent",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "LogDNA Agent streams from log files to your LogDNA account. Works with Linux, Windows, and macOS Servers",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     }
   },
   "dependencies": {
-    "@logdna/logger": "^2.2.0",
+    "@logdna/logger": "^2.2.2",
     "async": "^3.2.0",
     "commander": "^4.1.1",
     "debug": "^4.1.1",

--- a/tools/files/darwin/logdna-agent.rb
+++ b/tools/files/darwin/logdna-agent.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 cask "logdna-agent" do
-  version "2.2.0"
+  version "2.2.1"
   sha256 "b5c44e27cd6f4a92ff2eb12be09ff0be7e8a56309db33c139db42f5110a037fb"
 
   # github.com/logdna/logdna-agent/ was verified as official when first introduced to the cask

--- a/tools/files/win32/logdna-agent.nuspec
+++ b/tools/files/win32/logdna-agent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>logdna-agent</id>
     <title>LogDNA Agent for Windows</title>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <authors>smusali,leeliu</authors>
     <owners>leeliu</owners>
     <summary>LogDNA Agent for Windows</summary>


### PR DESCRIPTION
This is the agent bump includes the dependency bump as well.

Semver: patch