### PR TITLE
fix(ci): gate builds from contributors outside of org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,17 @@ pipeline {
   }
 
   stages {
+    stage('Validate PR Source') {
+      when {
+        expression { env.CHANGE_FORK }
+        not {
+          triggeredBy 'issueCommentCause'
+        }
+      }
+      steps {
+        error("A maintainer needs to approve this PR for CI by commenting")
+      }
+    }
     stage('Test Suite') {
       matrix {
         axes {

--- a/lib/file-utilities.js
+++ b/lib/file-utilities.js
@@ -10,7 +10,7 @@ const TailFile = require('@logdna/tail-file')
 
 const spawn = require('child_process').spawn
 
-const log = require('./utils').log
+const log = require('./utils.js').log
 
 const client = require('./logger-client.js')
 


### PR DESCRIPTION
To prevent builds from auto running on every pull request which has to potential to execute malicious code and expose secrets, we will require that a maintainer from within the org explicitly trigger a build.